### PR TITLE
Haoking: Projects page functionality, light/dark

### DIFF
--- a/js/src/personal/haoking/Haoking.module.css
+++ b/js/src/personal/haoking/Haoking.module.css
@@ -1,10 +1,3 @@
-.animate_fade_out {
-  animation-name: fade-out;
-  animation-duration: 1.25s;
-  animation-timing-function: ease;
-  animation-fill-mode: forwards;
-}
-
 .animate_fade_in {
   opacity: 0%;
   animation-name: fade-in;
@@ -49,31 +42,46 @@
 
 .navlink {
   text-decoration: none;
-  color: #d1d1d1;
+  color: var(--mantine-link);
   font-size: 20px;
-  font-family: Helvetica, sans-serif;
 }
 
 .navlink_current {
   text-decoration: none;
-  color: #fff;
+  color: var(--mantine-link-current);
   font-size: 20px;
-  font-family: Helvetica, sans-serif;
 }
 
 .hkbody a.navlink:hover {
-  color: beige;
+  color: var(--mantine-link-hover);
 }
 
-
-@keyframes fade-out {
-  from {opacity: 100%}
-  to {opacity: 0}
+.hkbody a.action:hover {
+  color: var(--mantine-action-hover);
 }
 
-@keyframes fade-in{
-  from {opacity: 0}
-  to {opacity: 100%}
+.project:hover {
+  animation-name: project-hover;
+  animation-duration: 0.5s;
+  animation-fill-mode: forwards;
 }
 
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
 
+  to {
+    opacity: 100%;
+  }
+}
+
+@keyframes project-hover {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(10px);
+  }
+}

--- a/js/src/personal/haoking/Haoking.page.tsx
+++ b/js/src/personal/haoking/Haoking.page.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { AboutMe } from './aboutme/AboutMe.tsx'
 import { ProjectsPage } from './projects/ProjectsPage.tsx'
 import { MiscPage } from './misc/MiscPage.tsx'
-import { theme } from './theme.ts'
+import { cssVariableResolver, theme } from './theme.ts'
 import { Pages } from './pages.ts'
 import styles from './Haoking.module.css'
 
@@ -11,7 +11,10 @@ export function HaokingPage() {
   const [current, setCurrent] = useState(Pages.About)
 
   return (
-    <MantineProvider theme={theme}>
+    <MantineProvider
+      theme={theme}
+      cssVariablesResolver={cssVariableResolver}
+    >
       <div className={styles.hkbody}>
         {current === Pages.About && (
           <AboutMe

--- a/js/src/personal/haoking/aboutme/AboutMe.tsx
+++ b/js/src/personal/haoking/aboutme/AboutMe.tsx
@@ -1,8 +1,7 @@
-import { Box, Flex, rem } from '@mantine/core'
+import { Box, Flex } from '@mantine/core'
 import { LeftAboutMe } from './LeftAboutMe.tsx'
 import { RightAboutMe } from './RightAboutMe.tsx'
 import { Navbar } from '../components/Navbar.tsx'
-import { theme } from '../theme.ts'
 import { Pages } from '../pages.ts'
 
 export function AboutMe({
@@ -13,11 +12,7 @@ export function AboutMe({
   setCurrent: any
 }) {
   return (
-    <Box
-      bg={theme.colors.black[4]}
-      h={rem('100vh')}
-      w={rem('100vw')}
-    >
+    <Box>
       <Navbar
         current={current}
         setCurrent={setCurrent}

--- a/js/src/personal/haoking/aboutme/LeftAboutMe.tsx
+++ b/js/src/personal/haoking/aboutme/LeftAboutMe.tsx
@@ -1,11 +1,20 @@
-import { Title, Text, Box, Flex, Image, ActionIcon } from '@mantine/core'
+import {
+  Title,
+  Text,
+  Box,
+  Flex,
+  Image,
+  ActionIcon,
+  useComputedColorScheme,
+} from '@mantine/core'
 import { IconBrandGithub, IconBrandLinkedin } from '@tabler/icons-react'
-import styles from '../Haoking.module.css'
 import { theme } from '../theme.ts'
+import styles from '../Haoking.module.css'
 import { Time } from '../components/Time.tsx'
 
 /* Component containing image, time, contact info on left side of about me page */
 export function LeftAboutMe() {
+  const colorScheme = useComputedColorScheme()
   return (
     <Box
       ml={90}
@@ -16,37 +25,36 @@ export function LeftAboutMe() {
         <Text
           inherit
           variant="gradient"
-          component="span"
-          gradient={{
-            from: theme.colors.black[0],
-            to: theme.colors.black[1],
-          }}
+          gradient={
+            colorScheme === 'light' ?
+              { from: theme.colors.accent[2], to: theme.colors.accent[1] }
+            : { from: theme.colors.black[0], to: theme.colors.black[1] }
+          }
         >
           {'Haoking Luo'}
         </Text>
       </Title>
       <Flex gap={15}>
-        <Title
-          fz={40}
-          c={theme.colors.white[0]}
-        >
-          {'swe guy'}
-        </Title>
+        <Title fz={40}>{'swe guy'}</Title>
         <ActionIcon
+          className={styles.action}
           component="a"
           href="https://github.com/luoh00"
           target="_blank"
           mt={15}
-          color="transparent"
+          variant="transparent"
+          color={colorScheme === 'light' ? theme.colors.accent[9] : 'gray'}
         >
           <IconBrandGithub size={24} />
         </ActionIcon>
         <ActionIcon
+          className={styles.action}
           component="a"
           href="https://linkedin.com/in/haoking-l-0a5ab61b3"
           target="_blank"
           mt={15}
-          color="transparent"
+          variant="transparent"
+          color={colorScheme === 'light' ? theme.colors.accent[9] : 'gray'}
         >
           <IconBrandLinkedin size={24} />
         </ActionIcon>

--- a/js/src/personal/haoking/aboutme/RightAboutMe.tsx
+++ b/js/src/personal/haoking/aboutme/RightAboutMe.tsx
@@ -1,15 +1,34 @@
-import { Title, Text, Box, AspectRatio, Divider } from '@mantine/core'
+import {
+  Title,
+  Text,
+  Box,
+  AspectRatio,
+  Divider,
+  useComputedColorScheme,
+} from '@mantine/core'
 import styles from '../Haoking.module.css'
-import { theme } from '../theme.ts'
 
 /* Component for basic info and spotify embed on right side of about me page */
 export function RightAboutMe() {
-  const text: string[] = [
-    'b.s. in cs @ rpi | class of 2027',
-    "bronx high school of science '23",
-    'i like eating food, playing videogames, skating',
-    'cats and raccoons',
+  const data = [
+    {
+      title: 'education',
+      subtitle: [
+        'b.s. in cs @ rpi | class of 2027',
+        "bronx high school of science '23",
+      ],
+    },
+    {
+      title: 'bio',
+      subtitle: [
+        'i like eating food, playing videogames, skating',
+        'cats and raccoons',
+        'fav song:',
+      ],
+    },
   ]
+  const colorScheme = useComputedColorScheme()
+
   return (
     <Box
       ml={90}
@@ -19,19 +38,18 @@ export function RightAboutMe() {
       className={styles.animate_fade_in_delay}
     >
       <Divider
+        color={colorScheme === 'light' ? '#000' : '#fff'}
         mt={120}
         pt={20}
         maw={350}
-        color={theme.colors.white[6]}
       />
-      <Title c={theme.colors.white[2]}>{'Info'}</Title>
-      {text.map((info) => (
-        <Text
-          c={theme.colors.white[2]}
-          pt={16}
-        >
-          {info}
-        </Text>
+      {data.map((text) => (
+        <div>
+          <Title pt={16}>{text.title}</Title>
+          {text.subtitle.map((sub) => (
+            <Text pt={16}>{sub}</Text>
+          ))}
+        </div>
       ))}
       <AspectRatio
         maw={400}

--- a/js/src/personal/haoking/components/Navbar.tsx
+++ b/js/src/personal/haoking/components/Navbar.tsx
@@ -1,7 +1,14 @@
-import { Group } from '@mantine/core'
+import {
+  Group,
+  ActionIcon,
+  useMantineColorScheme,
+  useComputedColorScheme,
+} from '@mantine/core'
+import { IconSunFilled, IconMoonFilled } from '@tabler/icons-react'
 import { NavLink } from './NavLink.tsx'
 import styles from '../Haoking.module.css'
 import { Pages } from '../pages.ts'
+import { theme } from '../theme.ts'
 
 /* Component for a navbar to lead to different pages*/
 export function Navbar({
@@ -16,6 +23,8 @@ export function Navbar({
     { link: '#projects', label: Pages.Project },
     { link: '#misc', label: Pages.Misc },
   ]
+  const { setColorScheme } = useMantineColorScheme()
+  const colorScheme = useComputedColorScheme()
 
   return (
     <nav>
@@ -48,6 +57,22 @@ export function Navbar({
               label={page.label}
             />
           ))}
+          <ActionIcon
+            onClick={
+              colorScheme === 'light' ?
+                () => setColorScheme('dark')
+              : () => setColorScheme('light')
+            }
+            variant="transparent"
+            color={
+              colorScheme === 'light' ?
+                theme.colors.accent[2]
+              : theme.colors.white[2]
+            }
+          >
+            {colorScheme === 'light' && <IconMoonFilled size={24} />}
+            {colorScheme === 'dark' && <IconSunFilled size={24} />}
+          </ActionIcon>
         </Group>
       </Group>
     </nav>

--- a/js/src/personal/haoking/components/Time.tsx
+++ b/js/src/personal/haoking/components/Time.tsx
@@ -1,6 +1,5 @@
 import { Box, Text } from '@mantine/core'
 import { useState, useEffect } from 'react'
-import { theme } from '../theme.ts'
 
 /* Component for displaying the current time */
 export function Time() {
@@ -21,7 +20,6 @@ export function Time() {
       <Text
         fw={700}
         fz={50}
-        c={theme.colors.white[6]}
       >
         {date.toLocaleTimeString()}
       </Text>

--- a/js/src/personal/haoking/misc/MiscPage.tsx
+++ b/js/src/personal/haoking/misc/MiscPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, rem, Text } from '@mantine/core'
+import { Box, Flex } from '@mantine/core'
 import { Navbar } from '../components/Navbar.tsx'
 import { theme } from '../theme.ts'
 import { Pages } from '../pages.ts'
@@ -11,20 +11,20 @@ export function MiscPage({
   setCurrent: any
 }) {
   return (
-    <Box
-      bg={theme.colors.black[4]}
-      h={rem('100vh')}
-      w={rem('100vw')}
-    >
+    <Box>
       <Navbar
         current={current}
         setCurrent={setCurrent}
       />
-      <Flex
-        justify="flex-start"
-        direction="row"
-      >
-        <Text>{'miscellaneous'}</Text>
+      <Flex justify={'center'}>
+        <Box
+          mt={150}
+          h={400}
+          w={400}
+          bg={theme.colors.white[0]}
+        >
+          {}
+        </Box>
       </Flex>
     </Box>
   )

--- a/js/src/personal/haoking/projects/LeftProjects.tsx
+++ b/js/src/personal/haoking/projects/LeftProjects.tsx
@@ -1,28 +1,51 @@
-import { Text, Title, Box } from '@mantine/core'
-import { theme } from '../theme.ts'
+import {
+  Text,
+  Title,
+  Box,
+  Flex,
+  Image,
+  useComputedColorScheme,
+} from '@mantine/core'
 import styles from '../Haoking.module.css'
+import { theme } from '../theme.ts'
 
 /* Component for left side of Projects page */
-export function LeftProjects() {
+export function LeftProjects({
+  displayedImageSrc,
+}: {
+  displayedImageSrc: string
+}) {
+  const colorScheme = useComputedColorScheme()
+
   return (
     <Box
       ml={90}
       mt={45}
       className={styles.animate_fade_in}
     >
-      <Title className={styles.title}>
-        <Text
-          inherit
-          variant="gradient"
-          component="span"
-          gradient={{
-            from: theme.colors.black[0],
-            to: theme.colors.black[1],
-          }}
-        >
-          {'Projects'}
-        </Text>
-      </Title>
+      <Flex direction="column">
+        <Title className={styles.title}>
+          <Text
+            inherit
+            variant="gradient"
+            component="span"
+            gradient={
+              colorScheme === 'light' ?
+                { from: theme.colors.accent[2], to: theme.colors.accent[1] }
+              : { from: theme.colors.black[0], to: theme.colors.black[1] }
+            }
+          >
+            {'Projects'}
+          </Text>
+        </Title>
+        <Image
+          className={
+            displayedImageSrc === '' ? styles.image : styles.animate_fade_in
+          }
+          h={displayedImageSrc === '' ? 0 : 200}
+          src={displayedImageSrc}
+        />
+      </Flex>
     </Box>
   )
 }

--- a/js/src/personal/haoking/projects/ProjectsPage.tsx
+++ b/js/src/personal/haoking/projects/ProjectsPage.tsx
@@ -1,8 +1,8 @@
-import { Box, rem, Flex } from '@mantine/core'
+import { Box, Flex } from '@mantine/core'
+import { useState } from 'react'
 import { LeftProjects } from './LeftProjects.tsx'
 import { RightProjects } from './RightProjects.tsx'
 import { Navbar } from '../components/Navbar.tsx'
-import { theme } from '../theme.ts'
 import { Pages } from '../pages.ts'
 
 export function ProjectsPage({
@@ -12,12 +12,10 @@ export function ProjectsPage({
   current: Pages
   setCurrent: any
 }) {
+  const [displayedImageSrc, setImage] = useState('')
+
   return (
-    <Box
-      bg={theme.colors.black[4]}
-      h={rem('100vh')}
-      w={rem('100vw')}
-    >
+    <Box>
       <Navbar
         current={current}
         setCurrent={setCurrent}
@@ -26,8 +24,8 @@ export function ProjectsPage({
         justify="space-between"
         direction="row"
       >
-        <LeftProjects />
-        <RightProjects />
+        <LeftProjects displayedImageSrc={displayedImageSrc} />
+        <RightProjects setImage={setImage} />
       </Flex>
     </Box>
   )

--- a/js/src/personal/haoking/projects/RightProjects.tsx
+++ b/js/src/personal/haoking/projects/RightProjects.tsx
@@ -1,52 +1,112 @@
-import { Text, Title, Box, Divider, Badge, Group } from '@mantine/core'
+import {
+  Text,
+  Title,
+  Box,
+  Divider,
+  Badge,
+  Group,
+  useComputedColorScheme,
+} from '@mantine/core'
+import { useHover } from '@mantine/hooks'
 import styles from '../Haoking.module.css'
 import { theme } from '../theme.ts'
 
 /* Component for right side of Projects page */
-export function RightProjects() {
+export function RightProjects({ setImage }: { setImage: any }) {
+  const colorScheme = useComputedColorScheme()
+  const { hovered: hovered1, ref: ref1 } = useHover()
+  const { hovered: hovered2, ref: ref2 } = useHover()
+  const { hovered: hovered3, ref: ref3 } = useHover()
+  const projectsData = [
+    {
+      title: 'Todo App',
+      subtitle: 'manage your tasks',
+      link: 'https://github.com/luohk000/todo-app',
+      image:
+        'https://i.natgeofe.com/k/6289c775-a06c-426a-badb-8d181a55237b/raccoon-grass_2x1.jpg',
+      tools: ['flutter'],
+      isHovered: hovered1,
+      ref: ref1,
+    },
+    {
+      title: 'Quiz App',
+      subtitle: 'quiz yourself',
+      link: 'https://github.com/luohk000/quizWIP',
+      image:
+        'https://m.media-amazon.com/images/I/71HJRIGU81L._AC_UF894,1000_QL80_.jpg',
+      tools: ['flutter', 'firebase'],
+      isHovered: hovered2,
+      ref: ref2,
+    },
+    {
+      title: 'Word Search Generator',
+      subtitle: 'fun stuff',
+      link: '',
+      image:
+        'https://www.westernpest.com/wp-content/uploads/Raccoon_in_Trash_iStock-91705369-scaled.jpg',
+      tools: ['c++'],
+      isHovered: hovered3,
+      ref: ref3,
+    },
+  ]
+
+  let anyHovered = false
+  projectsData.forEach((project) => {
+    if (project.isHovered) {
+      setImage(project.image)
+      anyHovered = true
+    }
+  })
+  if (!anyHovered) setImage('')
+
   return (
     <Box
       ml={90}
-      mr={350}
+      mr={300}
       mt={45}
-      maw={400}
+      maw={600}
       className={styles.animate_fade_in_delay}
     >
       <Divider
+        color={colorScheme === 'light' ? '#000' : '#fff'}
         mt={120}
         pt={20}
         maw={350}
-        color={theme.colors.white[6]}
       />
-      <Group>
-        <Title c={theme.colors.white[1]}>
-          <Text
-            inherit
-            component="a"
-            href="https://github.com/luohk000/todo-app"
-            target="_blank"
+      {projectsData.map((project) => (
+        <div>
+          <div
+            className={styles.project}
+            ref={project.ref}
           >
-            {'Todo App'}
-          </Text>
-        </Title>
-        <Badge color={theme.colors.black[6]}>{'Flutter'}</Badge>
-      </Group>
-      <Text c={theme.colors.white[2]}>{'manage your tasks'}</Text>
-      <Group>
-        <Title c={theme.colors.white[1]}>
-          <Text
-            inherit
-            component="a"
-            href="https://github.com/luohk000/quizWIP"
-            target="_blank"
-          >
-            {'Quiz App'}
-          </Text>
-        </Title>
-        <Badge color={theme.colors.black[6]}>{'Flutter'}</Badge>
-        <Badge color={theme.colors.black[6]}>{'Firebase'}</Badge>
-      </Group>
-      <Text c={theme.colors.white[2]}>{'quiz yourself'}</Text>
+            <Group>
+              <Title>
+                <Text
+                  className={styles.action}
+                  inherit
+                  component="a"
+                  href={project.link}
+                  target="_blank"
+                >
+                  {project.title}
+                </Text>
+              </Title>
+              {project.tools.map((tool) => (
+                <Badge
+                  color={
+                    colorScheme === 'light' ?
+                      theme.colors.accent[8]
+                    : theme.colors.black[6]
+                  }
+                >
+                  {tool}
+                </Badge>
+              ))}
+            </Group>
+          </div>
+          <Text mb={10}>{project.subtitle}</Text>
+        </div>
+      ))}
     </Box>
   )
 }

--- a/js/src/personal/haoking/theme.ts
+++ b/js/src/personal/haoking/theme.ts
@@ -1,4 +1,9 @@
-import { createTheme, DEFAULT_THEME, mergeMantineTheme } from '@mantine/core'
+import {
+  createTheme,
+  CSSVariablesResolver,
+  DEFAULT_THEME,
+  mergeMantineTheme,
+} from '@mantine/core'
 
 /**
  * Custom mantine theme override
@@ -12,14 +17,14 @@ export const themeOverride = createTheme({
     white: [
       '#f2f2f2',
       '#e0e0e0',
-      '#c9c9c9',
+      '#f5f5dc',
       '#f5fefd',
       '#fcfbfc',
       '#fdf6e4',
       '#fafafa',
       '#fbfcfa',
       '#fffefc',
-      '#faf9f6',
+      '#fcf8e3',
     ],
     black: [
       '#6b6b6b',
@@ -33,17 +38,17 @@ export const themeOverride = createTheme({
       '#1f1f1f',
       '#1a1a1a',
     ],
-    blue: [
-      '#7472db',
-      '#4536f7',
-      '#483fa1',
-      '#202378',
-      '#0e2159',
-      '#6484e3',
-      '#786dfc',
-      '#0b2f9c',
-      '#051440',
-      '#1b2540',
+    accent: [
+      '#c7aa83',
+      '#d9af77',
+      '#f5cda2',
+      '#edb374',
+      '#96a4e0',
+      '#ffc0cb',
+      '#f7b71b',
+      '#4f3e15',
+      '#82692e',
+      '#52421c',
     ],
   },
 
@@ -52,3 +57,28 @@ export const themeOverride = createTheme({
 })
 
 export const theme = mergeMantineTheme(DEFAULT_THEME, themeOverride)
+
+/**
+ * Used to change the default css variable linking.
+ *
+ * Mantine uses `--mantine-color-body` to render the background, and we can override it here.
+ * {@link https://mantine.dev/styles/css-variables/#css-variables-resolver}
+ */
+export const cssVariableResolver: CSSVariablesResolver = (computedTheme) => ({
+  variables: {},
+  light: {
+    '--mantine-color-body': computedTheme.colors.white[9],
+    '--mantine-link-hover': computedTheme.colors.accent[0],
+    '--mantine-link-current': computedTheme.colors.accent[7],
+    '--mantine-link': computedTheme.colors.accent[8],
+    '--mantine-color-text': computedTheme.colors.accent[9],
+    '--mantine-action-hover': computedTheme.colors.accent[1],
+  },
+  dark: {
+    '--mantine-color-body': computedTheme.colors.black[4],
+    '--mantine-link-hover': computedTheme.colors.white[2],
+    '--mantine-link-current': '#fff',
+    '--mantine-link': '#d1d1d1',
+    '--mantine-action-hover': computedTheme.colors.accent[5],
+  },
+})


### PR DESCRIPTION
Added a light/dark button on top navbar to switch between a light and dark mode color palette. Cleaned up About Me page by splitting right side content into sections with headings. Added a Projects page with github links to projects as well as placeholder images that pop up on the left side of the page when the corresponding project is hovered.

L=ENG-36
L=ENG-39