### PR TITLE
Gerrit: Add git pullg to pull from Gerrit

### DIFF
--- a/tools/git/.gitconfig
+++ b/tools/git/.gitconfig
@@ -7,4 +7,5 @@
 [alias]
 	pushf = push --force-with-lease --force-if-includes
 	pullo = pull origin main
+	pullg = pull gerrit main
 	rebaseo = rebase -i origin/main

--- a/tools/git/.gitconfig
+++ b/tools/git/.gitconfig
@@ -6,6 +6,6 @@
 	autoSetupRebase = always
 [alias]
 	pushf = push --force-with-lease --force-if-includes
-	pullo = pull origin main
+	pullo = pull gerrit main
 	pullg = pull gerrit main
 	rebaseo = rebase -i origin/main

--- a/tools/git/gerrit/setup.md
+++ b/tools/git/gerrit/setup.md
@@ -40,8 +40,8 @@ Used to store steps required to set up Gerrit.
 ## Setting up GerritHub repo
 - Clone Github Repo into GerritHub.
 - General -> Submit type -> `Rebase if necessary`
-- General -> Match authored date with committer date upon submit -> True
 - General -> Require Change-Id in commit message -> True
+- General -> Match authored date with committer date upon submit -> True
 - General -> Maximum Git object size limit -> 10m
 - General -> Reject Duplicate Pathnames -> True
 - General -> Reject Submodules -> true
@@ -49,6 +49,8 @@ Used to store steps required to set up Gerrit.
 - General -> Reject Windows Line Endings -> true
 - Access -> Set `Rights Inherit From` to `Private-Projects`
 - Access -> Add `Patina Network` group to all `refs/for/refs/*` default permissions.
+  - Add `Revert`
+  - Add `Toggle Work In Progress State`
 - Access -> Add `Patina Network` group to all `refs/heads/*` default permissions.
   - Remove pushMerge perm
   - Add `Label Code Review` and `Label Verified` perms

--- a/tools/git/gerrit/workflow.md
+++ b/tools/git/gerrit/workflow.md
@@ -6,10 +6,10 @@ steps until they gain an understanding and mastery of the tools.
 
 It is assumed that the steps in `gerrit/setup.md`'s local setup are complete.
 
-1. Starting from the `main` branch, update it to the most up to date by running `git pullo`
+1. Starting from the `main` branch, update it to the most up to date by running `git pullg`
 2. Create a new branch using `git switch -c branch/name`
 3. Commit as often as desired locally with temporary commit messages
-4. Regularly pull from origin/main throughout the process using `git pullo`
+4. Regularly pull from origin/main throughout the process using `git pullg`
    - If merge conflicts occur, a workflow to resolve it is included below
 5. Finish up feature
 6. Reorganize commits using various techniques:
@@ -43,7 +43,7 @@ TODO(Henry): Automate deletion of GitHub pull requests once shipped.
 
 
 ### Merge Conflicts 
-When running `git pullo`, it's possible that there are merge conflicts if a commit has been
+When running `git pullg`, it's possible that there are merge conflicts if a commit has been
 submitted to main that touched the same lines in the same files as your changes. Gerrit should
 prevent CRs from being shipped if merge conflicts exist.
 
@@ -51,7 +51,7 @@ Generally, merge conflicts should be resolved locally, and then pushed back up i
 This can be done by:
 1. Go to the branch with the changes 
    - Alternatively, checkout the branch from Gerrit using Download -> Checkout and Create Branch
-2. Run `git pullo` to rebase the commits in the branch onto origin/main
+2. Run `git pullg` to rebase the commits in the branch onto origin/main
 3. Look at which files have merge conflicts in Sublime Merge
 4. Open those files in IntelliJ or search the codebase (cmd+shift+f) for `>>>>>>`
 5. Resolve merge conflicts locally and save

--- a/tools/machine-setup/README.md
+++ b/tools/machine-setup/README.md
@@ -123,6 +123,9 @@ iTerm2
     # Set the prompt to display the full path.
     PROMPT=' %{$fg[cyan]%}%~%{$reset_color%} $(git_prompt_info)'
     
+    # Add custom git commands
+    export PATH=$HOME/patina/tools/git/commands:$PATH
+    
     # Git aliases
     alias gpo="git pull origin main"
     alias gpullo="git pull origin main"


### PR DESCRIPTION
Seems like I broke the Github sync in Gerrithub. For now we can use
Gerrithub as the source of truth and then fix it later.

Generally just use git pullg instead of git pull for most things.

Change-Id: Ia2da4ae024d61828ce613c1571d78e06ae75a784
