### PR TITLE
Haoking: Change Git Up, example-action for CI/CD

### DIFF
--- a/.github/workflows/example-action.yml
+++ b/.github/workflows/example-action.yml
@@ -1,7 +1,11 @@
 name: example-action
 run-name: ${{ github.actor }} is learning GitHub Actions
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      changeId:
+        description: 'Change-Id for Gerrit commit'
+        required: true
 env:
   RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   BOT_PWD: ${{ secrets.BOT_PATINA_HTTP_PASSWORD }}
@@ -24,11 +28,11 @@ jobs:
           curl -u bot-patina:$BOT_PWD -X POST \
             -H "Content-Type: application/json" \
             -d '{"message": "Test passed: '"$RUN_LINK"'", "labels": { "Verified": 1 } }' \
-            https://gerrithub.io/a/changes/I2947181181094f046463b01bed06d97bc14490b5/revisions/current/review
+            https://gerrithub.io/a/changes/${{ github.event.inputs.changeId }}/revisions/current/review
       - working-directory: .github/workflows
         if: failure()
         run: |
           curl -u bot-patina:$BOT_PWD -X POST \
             -H "Content-Type: application/json" \
             -d '{"message": "Test failed: '"$RUN_LINK"'", "labels": { "Verified": -1 } }' \
-            https://gerrithub.io/a/changes/I2947181181094f046463b01bed06d97bc14490b5/revisions/current/review
+            https://gerrithub.io/a/changes/${{ github.event.inputs.changeId }}/revisions/current/review

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          echo "a"
           echo "hiiiiii"
           echo "modifications . .. . .. ... "
           echo "TestInput: ${{ github.event.inputs.testInput }}"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,6 +12,8 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - run: |
+          echo "hiiiiii"
+          echo "modifications . .. . .. ... "
           echo "TestInput: ${{ github.event.inputs.testInput }}"
-

--- a/tools/git/commands/git-up
+++ b/tools/git/commands/git-up
@@ -68,6 +68,7 @@ if [ $commitsAheadIndex -lt 0 ]; then
 fi
 
 first_changeId=$(git cat-file commit HEAD~"$commitsAheadIndex" | grep "Change-Id:" | sed -n -e 's/^.*Change-Id: //p')
+
 changes=($(git log HEAD~"$commitsAhead"..HEAD | grep "Change-Id:" | awk '{sub(/Change-Id: /,"")}1'))
 [ $v = 1 ] && echo ""
 [ $v = 1 ] && echo "First Change-Id = $first_changeId"
@@ -98,6 +99,11 @@ if [ $pushToGerrit = 1 ]; then
     echo "Errors pushing to Gerrit"
     exit 1
   fi
+
+  # Run GitHub Actions workflow
+  [ $v = 1 ] && echo ""
+  [ $v = 1 ] && echo "----- Running Github Actions"
+  gh workflow run example-action -f changeId=${changes[1]}
 
 fi
 ####################################################################################################
@@ -133,8 +139,3 @@ if [ $updateGithub = 1 ]; then
     [ $commentOnPR = 1 ] && gh pr comment --body "New changes were pushed at $remoteGerritURL/q/$pullRequestChangeId"
   fi
 fi
-
-
-
-
-


### PR DESCRIPTION
Created GitHub Actions yml file called example-action that takes in a
Gerrit change-id as an input and calls pnpm run test on existing code.
If pnpm run test passes, bot patina account will verify +1 the CR
automatically, otherwise will verify with -1. Changed git up script
to automatically trigger this GitHub action.

Change-Id: I3a8d7a059f88f0f242c94cc747b4bb2e6add8554
