### PR TITLE
Git: Add commit message template

### DIFF
--- a/tools/git/.gitconfig
+++ b/tools/git/.gitconfig
@@ -9,3 +9,5 @@
 	pullo = pull gerrit main
 	pullg = pull gerrit main
 	rebaseo = rebase -i origin/main
+[commit]
+    template = tools/git/.gitmessage

--- a/tools/git/.gitmessage
+++ b/tools/git/.gitmessage
@@ -1,0 +1,34 @@
+# Title: Summary of the work
+
+
+
+# Wrap at 72 chars except for pasted URLs or code chunks.  72 is here: #
+# Example Commit Message:
+########################################################################
+# Service: Summary that is imperative, capitalized, and concise
+#
+# Blank line before body.
+# Body includes extra details especially about decisions made and why
+# they were made. Alternate approaches considered would be good too.
+# Helpful URLs could be in here as well.
+# Include task ID (Linear issue) and TEST and details below the body.
+#
+# L=ENG-998
+# L=ENG-999
+# TEST=(none|manual|compile|auto)
+# - Ran this automated test and it passed.
+# Link with details to successful run.
+# - Screenshot of page before and after
+# Link to screenshot.
+#
+########################################################################
+# How to Write a Git Commit Message:
+# 1. Separate subject from body with a blank line
+# 2. Limit the subject line to about 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why.
+#    - Explanations on the how should be included in inline comments.
+########################################################################


### PR DESCRIPTION
Adding a template to show an example of how commit messages should
generally be in this repo.

TEST=none

Change-Id: Ib19bf1a117789cbfc3c1f1dfb65f0fc0e37362b5
