### PR TITLE
PullReq: Create pull request for each commit

### DIFF
--- a/tools/git/commands/git-up
+++ b/tools/git/commands/git-up
@@ -6,7 +6,7 @@
 ####################################################################################################
 v=0 # verbose
 pushToGerrit=1
-updateGithub=0
+updateGithub=1
 commentOnPR=1
 
 print_usage() {
@@ -93,7 +93,7 @@ changes=($(git log HEAD~"$commitsAhead"..HEAD | grep "Change-Id:" | awk '{sub(/C
 [ $v = 1 ] && for x in $changes; do echo "-- $x";done
 
 ####################################################################################################
-# Update Gerrit
+# Update Gerrit and Github
 ####################################################################################################
 if [ $pushToGerrit = 1 ]; then
   [ $v = 1 ] && echo ""
@@ -131,40 +131,24 @@ if [ $pushToGerrit = 1 ]; then
       git push --force-with-lease origin ${commitId}:refs/heads/ci/${changes[idx]}
     else
       git push --quiet --force-with-lease origin ${commitId}:refs/heads/ci/${changes[idx]}
-    fi 
+    fi
     gh workflow run build-test -f changeId=${changes[idx]} -f branch="ci/${changes[idx]}"
+
+    if [ $updateGithub = 1 ]; then
+      [ $v = 1 ] && echo ""
+      [ $v = 1 ] && echo "----- Updating Github PRs"
+
+      pullRequestViewMsg=$(gh pr view "ci/${changes[idx]}" 2>&1)
+      [ $v = 1 ] && echo "gh pr view = $pullRequestViewMsg"
+
+      if [[ $pullRequestViewMsg =~ "no pull requests found" ]]; then
+        [ $v = 1 ] && echo ""
+        [ $v = 1 ] && echo "# Create a new PR for commit"
+        commitTitle=$(git log --format=%s -n 1 --skip=$(( $idx - 1 )))
+        commitMessage=$(git log --format=%b -n 1 --skip=$(( $idx - 1 )))
+        gh pr create --title ${commitTitle} --body ${commitMessage} --head "ci/${changes[idx]}"
+        [ $commentOnPR = 1 ] && gh pr comment "ci/${changes[idx]}" --body "Code Review comments can be found at $remoteGerritURL/q/${changes[idx]}"
+      fi
+    fi
   done
-fi
-####################################################################################################
-# Update Github
-####################################################################################################
-
-# Exit if Github should not be updated
-if [ $updateGithub = 1 ]; then
-  [ $v = 1 ] && echo ""
-  [ $v = 1 ] && echo "----- Updating Github PRs"
-
-  pullRequestViewMsg=$(gh pr view "$currentBranch" 2>&1)
-  pullRequestChangeId=$(gh pr view "$currentBranch" 2>&1 | grep "Change-Id:" | awk '{sub(/Change-Id: /,"")}1')
-  [ $v = 1 ] && echo "gh pr view = $pullRequestViewMsg"
-  [ $v = 1 ] && echo "First Change-Id = $first_changeId"
-  [ $v = 1 ] && echo "PR Change-Id = $pullRequestChangeId"
-
-  if [[ $pullRequestViewMsg =~ "no pull requests found" ]]; then
-    [ $v = 1 ] && echo ""
-    [ $v = 1 ] && echo "# Upload a new PR to Github if branch does not have one"
-    git push origin "$currentBranch"
-    gh pr create --fill-first
-    [ $commentOnPR = 1 ] && gh pr comment --body "Code Review comments can be found at $remoteGerritURL/q/$pullRequestChangeId"
-  elif [[ "$first_changeId" != "$pullRequestChangeId" ]]; then
-    [ $v = 1 ] && echo ""
-    [ $v = 1 ] && echo "# Check if the Pull Request still is for the oldest Change-Id."
-    gh pr close "$currentBranch" -c "Change-Id $pullRequestChangeId was closed at $remoteGerritURL/q/$pullRequestChangeId"
-    gh pr create --fill-first
-  else
-    [ $v = 1 ] && echo ""
-    [ $v = 1 ] && echo "# Force push new updates to existing Github PR"
-    git push --force-with-lease --force-if-includes origin "$currentBranch"
-    [ $commentOnPR = 1 ] && gh pr comment --body "New changes were pushed at $remoteGerritURL/q/$pullRequestChangeId"
-  fi
 fi


### PR DESCRIPTION
Added code to git up script to create a pull request on the
CI branch for each commit. Pull request is automatically closed
when Github Actions workflow deletes CI branches.

L=ENG-428
L=ENG-430

TEST=manual
- Ran git up to make sure pull requests are created for
each commit in chained commits
- Checked pull requests to make sure the commit subject and message
was used for the PR title and body
- Checked Github to see if pull requests closed automatically

closedPullRequest.png: https://patina-dev.nyc3.digitaloceanspaces.com/screenshot/Screenshot-2024-08-11T02:53:42-AmandaRuan-closedPullRequest.png

Change-Id: I105efbbef07502339d3e23112967ebd016771630