### PR TITLE
Blog: Add onClick functionality, More Posts sxn

### DIFF
--- a/js/src/Routes.tsx
+++ b/js/src/Routes.tsx
@@ -5,8 +5,6 @@ import { LilacPage } from '@/lilac/Lilac.page.tsx'
 import { LilacRoutes } from '@/lilac/Lilac.routes.tsx'
 import { AdminMainPage } from '@/patina/admin/AdminMain.page.tsx'
 import { AdminRoutes } from '@/patina/admin/Admin.routes.tsx'
-import { BlogRoutes } from '@/patina/pages/blog/Blog.routes.tsx'
-import { Blog } from '@/patina/pages/blog/Blog.tsx'
 
 export const Routes = [
   // Base path for hosting the patina website
@@ -33,12 +31,6 @@ export const Routes = [
     description: 'admin',
     element: <AdminMainPage />,
     children: AdminRoutes,
-  },
-  {
-    path: '/blog',
-    description: 'blog',
-    element: <Blog />,
-    children: BlogRoutes,
   },
   {
     path: '*',

--- a/js/src/patina/Patina.routes.tsx
+++ b/js/src/patina/Patina.routes.tsx
@@ -7,9 +7,10 @@ import { CommunityPage } from '@/patina/pages/community/Community.page.tsx'
 import { MentorPage } from '@/patina/pages/mentor/Mentor.page.tsx'
 import { VolunteerPage } from '@/patina/pages/volunteer/Volunteer.page.tsx'
 import { LoginPage } from '@/patina/login/Login.page.tsx'
-import { BlogPage } from '@/patina/pages/blog/Blog.page.tsx'
 import { InternshipPage } from '@/patina/pages/internship/Internship.page.tsx'
 import { OAuth2Page } from '@/patina/login/oauth2/OAuth2Page.tsx'
+import { BlogRoutes } from '@/patina/pages/blog/Blog.routes.tsx'
+import { Blog } from '@/patina/pages/blog/Blog.tsx'
 
 /**
  * Routes for the Patina Website
@@ -67,8 +68,9 @@ export const PatinaRoutes = [
   },
   {
     path: 'blog',
-    description: 'Blog Page',
-    element: <BlogPage />,
+    description: 'blog',
+    element: <Blog />,
+    children: BlogRoutes,
   },
   {
     path: 'internship',

--- a/js/src/patina/pages/blog/Blog.page.tsx
+++ b/js/src/patina/pages/blog/Blog.page.tsx
@@ -1,16 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { ImageCard } from './ImageCard.tsx'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
+import { Blog } from './blog.ts'
 import styles from './Blog.module.css'
-
-type Blog = {
-  id: number
-  author: string
-  title: string
-  createTime: string
-  content: string
-  image: string
-}
 
 /**
  * Component for displaying Blogs from DB in list view.
@@ -36,20 +28,8 @@ export function BlogPage() {
         <div className={styles.subtitleContainer}>{'Latest posts'}</div>
         {status === 'success' ?
           <div className={styles.latestPostsCards}>
-            <ImageCard
-              horizontal={false}
-              title={allBlogs[0].title}
-              content={allBlogs[0].content}
-              tags={['']}
-              image={allBlogs[0].image}
-            />
-            <ImageCard
-              horizontal={false}
-              title={allBlogs[1].title}
-              content={allBlogs[1].content}
-              tags={['']}
-              image={allBlogs[1].image}
-            />
+            <ImageCard horizontal={false} blog={allBlogs[0]} tags={['']} />
+            <ImageCard horizontal={false} blog={allBlogs[1]} tags={['']} />
           </div>
         : <div>{'Loading blogs...'}</div>}
       </div>
@@ -62,10 +42,8 @@ export function BlogPage() {
               <ImageCard
                 key={blog.id}
                 horizontal
-                title={blog.title}
-                content={blog.content}
+                blog={blog}
                 tags={['Summer 2024', 'Student Spotlight']}
-                image={blog.image}
               />
             ))}
           </div>

--- a/js/src/patina/pages/blog/Blog.tsx
+++ b/js/src/patina/pages/blog/Blog.tsx
@@ -1,24 +1,5 @@
-import { MantineProvider } from '@mantine/core'
 import { Outlet } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { resolver, theme } from '@/patina/theme.ts'
-import { NavBar } from '@/patina/navbar/NavBar.tsx'
-import { Footer } from '@/patina/components/Footer.tsx'
-
-const queryClient = new QueryClient()
 
 export function Blog() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <MantineProvider
-        theme={theme}
-        cssVariablesResolver={resolver}
-        forceColorScheme="dark"
-      >
-        <NavBar />
-        <Outlet />
-        <Footer />
-      </MantineProvider>
-    </QueryClientProvider>
-  )
+  return <Outlet />
 }

--- a/js/src/patina/pages/blog/FocusedBlog.module.css
+++ b/js/src/patina/pages/blog/FocusedBlog.module.css
@@ -1,10 +1,10 @@
+.editorRoot {
+  border: none;
+}
+
 .blogSection {
   display: block;
   padding: 25px;
-}
-
-.editorRoot {
-  border: none;
 }
 
 .titleText {
@@ -14,5 +14,29 @@
 
 .pillsSection {
   display: flex;
-  padding-top: 16px;
+  justify-content: flex-start;
+  gap: 6px;
+  padding-bottom: 4px;
+}
+
+.pill {
+  background-color: var(--mantine-color-dark-5);
+  border-radius: 4px;
+}
+
+.morePostsTitle {
+  font-weight: bold;
+}
+
+.morePostsSection {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.morePostsPosts {
+  display: flex;
+  justify-content: space-between;
+  margin: 24px;
+  gap: 12px;
 }

--- a/js/src/patina/pages/blog/FocusedBlog.tsx
+++ b/js/src/patina/pages/blog/FocusedBlog.tsx
@@ -1,11 +1,12 @@
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Image, Divider } from '@mantine/core'
+import { Image, Divider, Pill } from '@mantine/core'
 import { RichTextEditor } from '@mantine/tiptap'
 import { useEditor } from '@tiptap/react'
 import { useEffect } from 'react'
 import StarterKit from '@tiptap/starter-kit'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
+import { ImageCard } from './ImageCard.tsx'
 import styles from './FocusedBlog.module.css'
 
 /**
@@ -14,7 +15,7 @@ import styles from './FocusedBlog.module.css'
 export function FocusedBlog() {
   const { id } = useParams()
   const { data, status } = useQuery({
-    queryKey: ['blog'],
+    queryKey: ['blog', id],
     queryFn: async () => {
       const response = await fetch(`/api/blog/${id}`)
       if (!response.ok) {
@@ -25,6 +26,18 @@ export function FocusedBlog() {
   })
   const blog = data?.blog
 
+  const { data: dataListAll, status: statusListAll } = useQuery({
+    queryKey: ['blogs'],
+    queryFn: async () => {
+      const response = await fetch('/api/blogs')
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`)
+      }
+      return response.json()
+    },
+  })
+
+  const allBlogs = dataListAll?.blogs
   const editor = useEditor({
     extensions: [StarterKit],
     content: 'Loading this blog',
@@ -35,24 +48,36 @@ export function FocusedBlog() {
     if (status === 'success') {
       editor?.commands.setContent(JSON.parse(blog.content))
     }
-  }, [status])
+  }, [status, id])
 
   return status === 'success' ?
       <ContentPage>
         <Image src={blog.image} />
-        <div className={styles.pillsSection} />
         <div className={styles.blogSection}>
+          <div className={styles.pillsSection}>
+            <Pill className={styles.pill}>{'Student Spotlight'}</Pill>
+            <Pill className={styles.pill}>{'Summer 2024'}</Pill>
+          </div>
           <div className={styles.titleText}>{blog.title}</div>
           <Divider color={'white'} />
           <RichTextEditor
             classNames={{
               root: styles.editorRoot,
-              content: styles.editorContent,
             }}
             editor={editor}
           >
             <RichTextEditor.Content />
           </RichTextEditor>
+          <Divider color={'white'} />
+        </div>
+        <div className={styles.morePostsSection}>
+          <div className={styles.morePostsTitle}>{'More posts'}</div>
+          {statusListAll === 'success' ?
+            <div className={styles.morePostsPosts}>
+              <ImageCard horizontal={false} blog={allBlogs[5]} tags={['']} />
+              <ImageCard horizontal={false} blog={allBlogs[6]} tags={['']} />
+            </div>
+          : <div>{'Loading more blogs...'}</div>}
         </div>
       </ContentPage>
     : <div>{'Loading this blog'}</div>

--- a/js/src/patina/pages/blog/ImageCard.module.css
+++ b/js/src/patina/pages/blog/ImageCard.module.css
@@ -48,6 +48,6 @@
 }
 
 .imageVertical {
-  max-height: 600px;
+  max-height: 500px;
   border-radius: 10px;
 }

--- a/js/src/patina/pages/blog/ImageCard.tsx
+++ b/js/src/patina/pages/blog/ImageCard.tsx
@@ -1,4 +1,6 @@
-import { Image, Pill } from '@mantine/core'
+import { useNavigate } from 'react-router-dom'
+import { Image, Pill, UnstyledButton } from '@mantine/core'
+import { Blog } from './blog.ts'
 import styles from './ImageCard.module.css'
 
 /**
@@ -6,25 +8,18 @@ import styles from './ImageCard.module.css'
  */
 type ImageCardProps = {
   horizontal: boolean
-  title: string
-  content: string
+  blog: Blog
   tags: string[]
-  image: string
 }
 
-export function ImageCard({
-  horizontal,
-  title,
-  content,
-  tags,
-  image,
-}: ImageCardProps) {
+export function ImageCard({ horizontal, blog, tags }: ImageCardProps) {
+  const navigate = useNavigate()
   let contentSubstring = ''
   let JSONParsable = false
   // Content should be a JSON.stringify'd string
   // Convert content back to JSON object for accessing innermost text to display in brief
   try {
-    const contentJSON = JSON.parse(content)
+    const contentJSON = JSON.parse(blog.content)
     const innermostTextFields = contentJSON.content[0].content[0]
     contentSubstring = innermostTextFields.text.substring(0, 120)
     JSONParsable = true
@@ -32,27 +27,42 @@ export function ImageCard({
     console.log(e)
   }
   // Remove this once all existing blogs in SQL blog table have valid JSON parsable content column
-  if (!JSONParsable) contentSubstring = content.substring(0, 120)
+  if (!JSONParsable) contentSubstring = blog.content.substring(0, 120)
 
   return (
-    <div className={styles.border}>
-      <div className={horizontal ? styles.cardHorizontal : styles.cardVertical}>
-        <Image
-          className={horizontal ? styles.imageHorizontal : styles.imageVertical}
-          src={image === '' ? 'https://placehold.co/600x400' : image}
-        />
-        <div className={styles.textSection}>
-          <div className={styles.textTitle}>{title}</div>
-          <div className={styles.textDesc}>{contentSubstring}</div>
-          <div className={styles.pillsSection}>
-            {tags.map((tag, index: number) => (
-              <Pill key={index} className={styles.pill}>
-                {tag}
-              </Pill>
-            ))}
+    <UnstyledButton
+      onClick={() => {
+        console.log(`Navigating to blog ${blog.id}`)
+        navigate(`/blog/${blog.id}`)
+      }}
+    >
+      <div className={styles.border}>
+        <div
+          className={horizontal ? styles.cardHorizontal : styles.cardVertical}
+        >
+          <Image
+            className={
+              horizontal ? styles.imageHorizontal : styles.imageVertical
+            }
+            src={
+              blog.image.substring(0, 5) !== 'https' ?
+                'https://placehold.co/600x400'
+              : blog.image
+            }
+          />
+          <div className={styles.textSection}>
+            <div className={styles.textTitle}>{blog.title}</div>
+            <div className={styles.textDesc}>{contentSubstring}</div>
+            <div className={styles.pillsSection}>
+              {tags.map((tag, index: number) => (
+                <Pill key={index} className={styles.pill}>
+                  {tag}
+                </Pill>
+              ))}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </UnstyledButton>
   )
 }

--- a/js/src/patina/pages/blog/blog.ts
+++ b/js/src/patina/pages/blog/blog.ts
@@ -1,0 +1,8 @@
+export type Blog = {
+  id: number
+  author: string
+  title: string
+  createTime: string
+  content: string
+  image: string
+}


### PR DESCRIPTION
Refactored Blog type into its own .ts file. Refactored ImageCard to take
in a Blog object rather than all a blog's fields. Refactored BlogRoutes
into PatinaRoutes rather than the top level Routes. ImageCard is now
wrapped inside an UnstyledButton and onClick will navigate to the
blog page showing that specific blog. Made FocusedBlog component run
useEffect on id route param change, add another useQuery to get allBlogs
to show in More Posts section, make useEffect refetch to blog GET
endpoint with the id of the blog you clicked on.

https://patina-dev.nyc3.digitaloceanspaces.com/screenshot/Screenshot-2024-08-12T20:59:05-HaokingLuo-helpme.png

L=ENG-438
TEST=manual
- Ran gw bootRun and navigate to Blog page
- Clicked on a blog, displays all its info
- Clicked on another blog in More Posts section, new blog's info shown

Change-Id: I256ad857040c055ca25da9719a3467edc7a6f134