### PR TITLE
Blogs: Add Pagination component

### DIFF
--- a/js/src/patina/pages/blog/Blog.page.tsx
+++ b/js/src/patina/pages/blog/Blog.page.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
-import { Select } from '@mantine/core'
+import { Center, Pagination, Select } from '@mantine/core'
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { ImageCard } from './ImageCard.tsx'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
 import { Blog } from './blog.ts'
@@ -10,16 +10,17 @@ import styles from './Blog.module.css'
  * Component for displaying Blogs from DB in list view.
  */
 export function BlogPage() {
-  const [value, setValue] = useState<string | null>('10')
+  const [limit, setLimit] = useState<string | null>('10')
+  const [activePage, setActivePage] = useState(1)
   const { data, status } = useQuery({
-    queryKey: ['blogs', value],
+    queryKey: ['blogs', limit],
     queryFn: async () => {
       const response = await fetch('/api/blogs', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ limit: Number(value) }),
+        body: JSON.stringify({ limit: Number(limit) }),
       })
 
       if (!response.ok) {
@@ -30,6 +31,7 @@ export function BlogPage() {
   })
 
   const allBlogs = data?.blogs
+  const total = data?.total
 
   return (
     <ContentPage>
@@ -52,8 +54,8 @@ export function BlogPage() {
             placeholder="Pick value"
             data={['5', '10', '20', '50']}
             defaultValue="10"
-            value={value}
-            onChange={setValue}
+            value={limit}
+            onChange={setLimit}
           />
         </div>
         {status === 'success' ?
@@ -68,6 +70,13 @@ export function BlogPage() {
             ))}
           </div>
         : <div>{'Loading blogs...'}</div>}
+        <Center>
+          <Pagination
+            total={total / Number(limit) + 1}
+            value={activePage}
+            onChange={setActivePage}
+          />
+        </Center>
       </div>
     </ContentPage>
   )

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/blogs.proto
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/blogs.proto
@@ -48,6 +48,7 @@ message ListBlogReq {
 
 message ListBlogResp {
   repeated Blog blogs = 1;
+  int32 total = 2;
 }
 
 message GetBlogResp {

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/ops/ListOp.java
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/ops/ListOp.java
@@ -19,8 +19,9 @@ public class ListOp {
 
     public ListBlogResp run(ListBlogReq request) {
         int limit = request.getLimit() != 0 ? request.getLimit() : 10;
+        int total = blogsRepo.getBlogCount();
         List<Blog> blogs = blogsRepo.listBlogs(limit);
         // Sort blogs based on create_time here
-        return ListBlogResp.newBuilder().addAllBlogs(blogs).build();
+        return ListBlogResp.newBuilder().addAllBlogs(blogs).setTotal(total).build();
     }
 }

--- a/src/test/java/org/patinanetwork/patinawebsite/blogs/BlogsListOpTest.java
+++ b/src/test/java/org/patinanetwork/patinawebsite/blogs/BlogsListOpTest.java
@@ -49,7 +49,8 @@ public class BlogsListOpTest {
         ListBlogResp resp = op.run(request);
 
         // Assert
-        ListBlogResp expected = ListBlogResp.newBuilder().addBlogs(blog1).build();
+        ListBlogResp expected =
+                ListBlogResp.newBuilder().addBlogs(blog1).setTotal(1).build();
         assertEquals(expected, resp);
     }
 
@@ -82,8 +83,11 @@ public class BlogsListOpTest {
         ListBlogResp resp = op.run(request);
 
         // Assert
-        ListBlogResp expected =
-                ListBlogResp.newBuilder().addBlogs(blog1).addBlogs(blog2).build();
+        ListBlogResp expected = ListBlogResp.newBuilder()
+                .addBlogs(blog1)
+                .addBlogs(blog2)
+                .setTotal(2)
+                .build();
         assertEquals(expected, resp);
     }
 


### PR DESCRIPTION
Add a page selection component at the bottom of the blogs page. Length
is hard coded, and the current page is stored as 'activePage'. Added
total pages from back end to the pagination component.

TEST=manual, auto
Passed all 5 unit tests

Change-Id: Ic1ff7269682b0f2fefe09fa3b6634419dc0d9334