### PR TITLE
Blogs: Enable Pagination

### DIFF
--- a/js/src/patina/pages/blog/Blog.page.tsx
+++ b/js/src/patina/pages/blog/Blog.page.tsx
@@ -1,5 +1,5 @@
 import { Center, Pagination, Select } from '@mantine/core'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ImageCard } from './ImageCard.tsx'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
@@ -13,14 +13,14 @@ export function BlogPage() {
   const [limit, setLimit] = useState<string | null>('10')
   const [activePage, setActivePage] = useState(1)
   const { data, status } = useQuery({
-    queryKey: ['blogs', limit],
+    queryKey: ['blogs', limit, activePage],
     queryFn: async () => {
       const response = await fetch('/api/blogs', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ limit: Number(limit) }),
+        body: JSON.stringify({ limit: Number(limit), page: activePage }),
       })
 
       if (!response.ok) {
@@ -32,6 +32,10 @@ export function BlogPage() {
 
   const allBlogs = data?.blogs
   const total = data?.total
+
+  useEffect(() => {
+    setActivePage(1)
+  }, [limit])
 
   return (
     <ContentPage>
@@ -72,7 +76,7 @@ export function BlogPage() {
         : <div>{'Loading blogs...'}</div>}
         <Center>
           <Pagination
-            total={total / Number(limit) + 1}
+            total={Math.ceil(total / Number(limit))}
             value={activePage}
             onChange={setActivePage}
           />

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/blogs.proto
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/blogs.proto
@@ -44,6 +44,7 @@ message CreateBlogResp{
 
 message ListBlogReq {
   int32 limit = 1;
+  int32 page = 2;
 }
 
 message ListBlogResp {

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/ops/ListOp.java
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/ops/ListOp.java
@@ -19,8 +19,9 @@ public class ListOp {
 
     public ListBlogResp run(ListBlogReq request) {
         int limit = request.getLimit() != 0 ? request.getLimit() : 10;
+        int page = request.getPage();
         int total = blogsRepo.getBlogCount();
-        List<Blog> blogs = blogsRepo.listBlogs(limit);
+        List<Blog> blogs = blogsRepo.listBlogs(limit, page);
         // Sort blogs based on create_time here
         return ListBlogResp.newBuilder().addAllBlogs(blogs).setTotal(total).build();
     }

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/BlogsRepo.java
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/BlogsRepo.java
@@ -12,7 +12,7 @@ public interface BlogsRepo {
     Blog getBlogById(int id);
 
     // List blogs
-    List<Blog> listBlogs(int limit);
+    List<Blog> listBlogs(int limit, int page);
 
     // Get the size of blog table
     int getBlogCount();

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/FakeBlogsRepo.java
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/FakeBlogsRepo.java
@@ -27,7 +27,7 @@ public class FakeBlogsRepo implements BlogsRepo {
     }
 
     @Override
-    public List<Blog> listBlogs(int limit) {
+    public List<Blog> listBlogs(int limit, int page) {
         return blogs.values().stream().limit(limit).toList();
     }
 

--- a/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/PsqlBlogsRepo.java
+++ b/src/main/java/org/patinanetwork/patinawebsite/blogs/repo/PsqlBlogsRepo.java
@@ -50,13 +50,14 @@ public class PsqlBlogsRepo implements BlogsRepo {
     }
 
     @Override
-    public List<Blog> listBlogs(int limit) {
+    public List<Blog> listBlogs(int limit, int page) {
         List<Blog> blogs = new ArrayList<>();
         String sql =
-                "SELECT id, author, title, content, create_time, image FROM blog WHERE author <> 'ChatGPT' ORDER BY create_time DESC LIMIT ?";
+                "SELECT id, author, title, content, create_time, image FROM blog WHERE author <> 'ChatGPT' ORDER BY create_time DESC LIMIT ? OFFSET ?";
 
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, limit);
+            stmt.setInt(2, (page - 1) * limit);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     blogs.add(getBlog(rs));
@@ -71,7 +72,7 @@ public class PsqlBlogsRepo implements BlogsRepo {
 
     @Override
     public int getBlogCount() {
-        String sql = "SELECT COUNT(*) FROM blog";
+        String sql = "SELECT COUNT(*) FROM blog WHERE author <> 'ChatGPT'";
         try (PreparedStatement stmt = conn.prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery()) {
             if (rs.next()) {


### PR DESCRIPTION
Added the active page to the listBlogReq. An offset is added to the
listBlogs query and is created using the active page and limit.
Some logic changes including resetting the active page to 1 when
changing the 'Blogs per page' to avoid indexing issues.

TEST=manual
Ran page locally and validated feature works

Change-Id: Id55767108d20319debb7437ea8acd3d05b8b58e0