### PR TITLE
AdminBlog: Add Pagination to DataTable

### DIFF
--- a/js/src/patina/admin/blog/BlogDataTable.tsx
+++ b/js/src/patina/admin/blog/BlogDataTable.tsx
@@ -1,6 +1,6 @@
 import { DataTable } from 'mantine-datatable'
 
-const PAGE_SIZES = [10, 15, 20]
+const PAGE_SIZES = [10, 20, 50]
 
 type BlogRowType = {
   id: number


### PR DESCRIPTION
Allow the 'Edit Blog' section to view all blogs by page. Lets the user
select a page and set the number of blogs per page.

TEST=manual
Ran page locally to verify feature works

Change-Id: I46980bc46582bc730e09145ac4e64428d53e0dc3