### PR TITLE
AdminBlog: Add actions to DataTable

### DIFF
--- a/js/src/patina/admin/blog/BlogDataTable.tsx
+++ b/js/src/patina/admin/blog/BlogDataTable.tsx
@@ -1,6 +1,6 @@
 import { DataTable } from 'mantine-datatable'
 
-const PAGE_SIZES = [10, 15, 20]
+const PAGE_SIZES = [10, 20, 50]
 
 type BlogRowType = {
   id: number

--- a/js/src/patina/admin/blog/BlogDataTable.tsx
+++ b/js/src/patina/admin/blog/BlogDataTable.tsx
@@ -1,4 +1,5 @@
 import { DataTable } from 'mantine-datatable'
+import { EditActions } from './EditActions.tsx'
 
 const PAGE_SIZES = [10, 20, 50]
 
@@ -33,6 +34,12 @@ export function BlogDataTable({
         { accessor: 'author' },
         { accessor: 'title' },
         { accessor: 'createTime' },
+        {
+          accessor: 'actions',
+          title: 'Actions',
+          width: '0%',
+          render: (row) => <EditActions blogID={row.id} />,
+        },
       ]}
       records={records}
       totalRecords={total}

--- a/js/src/patina/admin/blog/EditActions.tsx
+++ b/js/src/patina/admin/blog/EditActions.tsx
@@ -1,0 +1,35 @@
+import { ActionIcon, Group } from '@mantine/core'
+import { IconEdit, IconEye, IconTrash } from '@tabler/icons-react'
+
+export function EditActions({ blogID }: { blogID: number }) {
+  return (
+    <Group gap={4} justify="left" wrap="nowrap">
+      <ActionIcon
+        size="sm"
+        variant="subtle"
+        color="green"
+        onClick={() => {
+          window.open(`${window.location.origin}/blog/${blogID}`)
+        }}
+      >
+        <IconEye size={16} />
+      </ActionIcon>
+      <ActionIcon
+        size="sm"
+        variant="subtle"
+        color="blue"
+        onClick={() => console.log('Edit')}
+      >
+        <IconEdit size={16} />
+      </ActionIcon>
+      <ActionIcon
+        size="sm"
+        variant="subtle"
+        color="red"
+        onClick={() => console.log('Delete')}
+      >
+        <IconTrash size={16} />
+      </ActionIcon>
+    </Group>
+  )
+}


### PR DESCRIPTION
Added an ActionButtons component to view, edit, and delete a blog. You
can view a selected blog. Edit and Delete print to console as they have
not been implemented yet.

TEST=manual
Ran page locally to verify feature works.

Change-Id: I8e70a81b8e463671cac9ac8912032663bc02c4bf