### PR TITLE
ContentPage: Allow transition to consistent gap

### DIFF
--- a/js/build.gradle.kts
+++ b/js/build.gradle.kts
@@ -3,6 +3,7 @@ import com.github.gradle.node.pnpm.task.PnpmTask
 
 plugins {
     java
+    idea
     id("com.github.node-gradle.node") version "7.0.2"
 }
 
@@ -16,7 +17,23 @@ val buildTask = tasks.register<PnpmTask>("patina") {
     group = "Patina"
     description = "Builds the frontend for Patina through Vite."
     dependsOn("pnpmInstall")
-    args.set(listOf("run", "build","--emptyOutDir", "--outDir", "${rootProject.layout.buildDirectory.dir("resources/main/static").get()}"))
+    args.set(
+        listOf(
+            "run",
+            "build",
+            "--emptyOutDir",
+            "--outDir",
+            "${rootProject.layout.buildDirectory.dir("resources/main/static").get()}"
+        )
+    )
     outputs.dir(rootProject.layout.buildDirectory.dir("resources/main/static"))
     inputs.files(fileTree("."))
+}
+
+idea {
+    module {
+        excludeDirs.add(file(".stylelintcache"))
+        excludeDirs.add(file(".eslintcache"))
+        excludeDirs.add(file("pnpm-lock.yaml"))
+    }
 }

--- a/js/src/patina/components/ContentPage.tsx
+++ b/js/src/patina/components/ContentPage.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import styles from './ContentPage.module.css'
 
 type ContentPageProps = {
+  gap?: number
   children: React.ReactNode
 }
 
@@ -10,10 +11,10 @@ type ContentPageProps = {
  * Page wrapper for content pages across the Patina Website to keep a consistent
  * style.
  */
-export function ContentPage({ children }: ContentPageProps) {
+export function ContentPage({ gap, children }: ContentPageProps) {
   return (
     <div className={styles.page}>
-      <Stack align={'center'} gap={0}>
+      <Stack align={'center'} gap={gap || 0}>
         {children}
       </Stack>
     </div>

--- a/js/src/patina/components/Hero.module.css
+++ b/js/src/patina/components/Hero.module.css
@@ -3,11 +3,12 @@
   flex-direction: row;
   width: 100%;
   margin-bottom: 84px;
-  padding-top: 64px;
+  padding-top: 48px;
 
   @mixin smaller-than $mantine-breakpoint-md {
     align-items: center;
     flex-direction: column;
+    padding-top: 36px;
     margin-bottom: 36px;
   }
 }

--- a/js/src/patina/pages/mentor/Mentor.page.tsx
+++ b/js/src/patina/pages/mentor/Mentor.page.tsx
@@ -1,10 +1,14 @@
-import { Text } from '@mantine/core'
+import { Button, Center, Space, Text, useMantineTheme } from '@mantine/core'
 import { Hero } from '@/patina/components/Hero'
 // import { Impact } from '@/patina/pages/mentor/impact/Impact'
 import { About } from '@/patina/pages/mentor/about/About'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
 import { imageUrls } from '@/patina/assets/images'
 import styles from './Mentor.module.css'
+import { ProgramDetails } from '@/patina/pages/mentor/program/ProgramDetails.tsx'
+
+const mentorGoogleFormUrl =
+  'https://docs.google.com/forms/d/1yWPT7gYtpiKbBO6IKgcTygTzuHdAZaSomgu0BnDW23s/viewform'
 
 /**
  * Mentor page allows people to apply to be mentors.
@@ -13,7 +17,7 @@ export function MentorPage() {
   const message = (
     <Text className={styles.description}>
       {
-        'Make a difference in a student’s career by becoming a Patina Network mentor.'
+        'Share your expertise and make a meaningful impact by mentoring the next generation of AANHPI and ally professionals. Join us to help cultivate diverse talent, foster cultural awareness, and shape a more inclusive future in your industry.'
       }
     </Text>
   )
@@ -24,12 +28,38 @@ export function MentorPage() {
         details={message}
         img={imageUrls.mentorApplyHero.src}
         alt={imageUrls.mentorApplyHero.alt}
-        buttonLink="https://docs.google.com/forms/d/1yWPT7gYtpiKbBO6IKgcTygTzuHdAZaSomgu0BnDW23s/viewform"
-        buttonText="Apply to be a mentor"
+        buttonLink={mentorGoogleFormUrl}
+        buttonText="Apply to be a mentor today!"
         buttonColor={'var(--mantine-color-patina-blue-light)'}
       />
       <About />
+      <Space h={64} />
+      <ProgramDetails />
+      <Space h={64} />
+      <ApplyButton />
+      <Space h={64} />
       {/*<Impact />*/}
     </ContentPage>
+  )
+}
+
+function ApplyButton() {
+  const theme = useMantineTheme()
+
+  return (
+    <Center>
+      <Button
+        component="a"
+        variant="filled"
+        color={theme.other.patinaBlueLight}
+        autoContrast
+        target="_blank"
+        href={mentorGoogleFormUrl}
+      >
+        <Text c={'black'} size="20">
+          {'Apply to be a mentor here!'}
+        </Text>
+      </Button>
+    </Center>
   )
 }

--- a/js/src/patina/pages/mentor/about/About.module.css
+++ b/js/src/patina/pages/mentor/about/About.module.css
@@ -1,38 +1,39 @@
 .about {
-  margin-bottom: 112px;
-  margin-top: 64px;
+  gap: 24px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    gap: 48px;
+    flex-direction: column;
+  }
 }
 
-.aboutTitle,
-.timeCommitmentTitle {
-  color: white;
-  font-weight: 700;
-  line-height: 35px;
-  font-size: 26px;
-}
-
-.aboutText,
-.timeCommitmentText {
-  color: white;
-  font-weight: 400;
-  line-height: 28px;
-  font-size: 18px;
-}
-
-.left {
-  width: 538px;
-  height: 309px;
-  justify-content: center;
-  justify-items: center;
-  display: contents;
+.aboutText {
+  max-width: 600px;
 }
 
 .quote {
+  justify-self: center;
+  align-self: center;
+  margin-right: 64px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin: 0;
+  }
+}
+
+.quoteText {
   margin: 64px;
   color: white;
-  text-align: left;
+  text-align: center;
   font-weight: 700;
   font-size: 34px;
+  height: auto;
+
+  @mixin smaller-than $mantine-breakpoint-xs {
+    text-align: left;
+    margin: 24px;
+    font-size: 28px;
+  }
 }
 
 .quoteAuthor {

--- a/js/src/patina/pages/mentor/about/About.tsx
+++ b/js/src/patina/pages/mentor/about/About.tsx
@@ -1,44 +1,35 @@
-import { Paper, SimpleGrid, Text } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import { Flex, Paper, Space, Stack, Text, Title } from '@mantine/core'
 import styles from './About.module.css'
 
 // Defining the About component
 export function About() {
-  const largeScreen = useMediaQuery('(min-width: 60em)')
   return (
-    <SimpleGrid
-      cols={largeScreen ? 2 : 1}
-      spacing="xl"
-      className={styles.about}
-    >
-      <div className={styles.left}>
-        <Paper withBorder>
-          <Text className={styles.quote}>
+    <Flex className={styles.about}>
+      <Stack className={styles.quote}>
+        <Paper withBorder h={'fit-content'}>
+          <Text className={styles.quoteText}>
             {
-              '"... given me insight on how to properly prepare for my job search and a glimpse of what my future could be”'
+              '"It\'s given me insight on how to properly prepare for my job search and a glimpse of what my future could be”'
             }
             <Text inherit className={styles.quoteAuthor}>
               {' - Amanda'}
             </Text>
           </Text>
         </Paper>
-      </div>
-      <div>
-        <h2 className={styles.aboutTitle}>
-          {'What it means to be a Patina Network Mentor'}
-        </h2>
-        <Text className={styles.aboutText}>
+      </Stack>
+      <div className={styles.aboutText}>
+        <Title order={2}>{'About the Program'}</Title>
+        <Space h={'sm'} />
+        <Text size={'lg'}>
           {
-            'We want our students to find their kuyas, sunbaes, and kakaks in their industries. Mentors are paired with students that match the best with their skills, learning styles, and industry. Our students are eager to learn about the realities of the workplace, networking for success, and transitioning into jobs. '
+            "In today’s competitive job market, having a trusted mentor can make all the difference in a young professional's career. By joining our program, you’ll have the opportunity to shape the next generation of leaders, offering insights that go beyond textbooks and lectures. Your personal experiences, both successes and challenges, will help students understand what it takes to succeed in their chosen fields and empower them to navigate the unique challenges faced by AANHPI individuals in the workplace."
           }
-        </Text>
-        <h2 className={styles.timeCommitmentTitle}>{'Time Commitment'}</h2>
-        <Text className={styles.timeCommitmentText}>
+          <p />
           {
-            'The level of time commitment is flexible, but we expect our mentors to be available online and/or in-person for at least five hours each month. Mentors are expected to check in with their mentees at least every other week and attend the monthly Patina Network networking events.'
+            "In addition to one-on-one mentoring, you'll also engage in group activities that foster cultural awareness and inclusion, ensuring that each student leaves the program not just as a skilled professional but as a strong advocate for diversity and inclusion."
           }
         </Text>
       </div>
-    </SimpleGrid>
+    </Flex>
   )
 }

--- a/js/src/patina/pages/mentor/program/ProgramDetails.module.css
+++ b/js/src/patina/pages/mentor/program/ProgramDetails.module.css
@@ -1,0 +1,24 @@
+.programDetails {
+  margin-inline: 64px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin-inline: 0;
+  }
+}
+
+.timelineSection {
+  margin-bottom: 24px;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.programDescription {
+  flex: 1;
+  margin-inline: 64px;
+  min-width: 300px;
+  font-size: 20px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin-inline: 0;
+  }
+}

--- a/js/src/patina/pages/mentor/program/ProgramDetails.tsx
+++ b/js/src/patina/pages/mentor/program/ProgramDetails.tsx
@@ -1,0 +1,168 @@
+import {
+  Flex,
+  Group,
+  List,
+  Space,
+  Stack,
+  Text,
+  ThemeIcon,
+  Timeline,
+  Title,
+  useMantineTheme,
+} from '@mantine/core'
+import { FaPeopleArrows, FaUsers } from 'react-icons/fa'
+import styles from './ProgramDetails.module.css'
+
+/** Displays details for the mentorship program for mentors */
+export function ProgramDetails() {
+  return (
+    <Stack className={styles.programDetails}>
+      <Flex justify={'center'}>
+        <Title order={2}>{'Program Details'}</Title>
+      </Flex>
+      <Space h={22} />
+      <Group className={styles.timelineSection}>
+        <Stack align={'center'}>
+          <ProgrammingSummary />
+          <Space h={8} />
+          <ProgramTimeline />
+        </Stack>
+        <ProgramText />
+      </Group>
+    </Stack>
+  )
+}
+
+function ProgramTimeline() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <Title order={3}>{'Timeline'}</Title>
+      <Timeline
+        ml={8}
+        mb={16}
+        color={theme.other.patinaBlueLight}
+        bulletSize={24}
+        lineWidth={2}
+      >
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'September 14'}
+            </Text>
+          }
+          fw={700}
+        >
+          <Text mt={4}>{'Introduction to your mentee'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'September 22'}
+            </Text>
+          }
+        >
+          <Text mt={4}>{'Virtual onboarding meeting'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'Week of September 23'}
+            </Text>
+          }
+          lineVariant="dashed"
+        >
+          <Text mt={4}>{'Beginning of the program'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'Week of December 14'}
+            </Text>
+          }
+          lineVariant="dashed"
+        >
+          <Text mt={4}>{'Last week of the program'}</Text>
+        </Timeline.Item>
+      </Timeline>
+    </>
+  )
+}
+
+function ProgrammingSummary() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <Title order={3}>{'Programming'}</Title>
+      <List spacing="xs" size="sm" center>
+        <List.Item
+          icon={
+            <ThemeIcon color={'dark.4'} size={28} radius="xl">
+              <FaPeopleArrows size={18} />
+            </ThemeIcon>
+          }
+        >
+          <Text c={theme.other.patinaBlueLight}>
+            {'Weekly: '}
+            <Text span c={'dark.0'}>
+              {'1:1 with Mentee'}
+            </Text>
+          </Text>
+        </List.Item>
+        <List.Item
+          icon={
+            <ThemeIcon color={'dark.4'} size={28} radius="xl">
+              <FaUsers size={18} />
+            </ThemeIcon>
+          }
+        >
+          <Text c={theme.other.patinaBlueLight}>
+            {'Monthly (In-Person): '}
+            <Text span c={'dark.0'}>
+              {'Group Event'}
+            </Text>
+          </Text>
+        </List.Item>
+      </List>
+    </>
+  )
+}
+
+function ProgramText() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <div className={styles.programDescription}>
+        <Text inherit>
+          {
+            'For the fall semester, we are looking to pair mentees one-on-one with a mentor, so that each mentee can have an experience tailored to their individual situation, needs and direction.'
+          }
+        </Text>
+        <p />
+        <Text inherit>
+          {
+            'For the duration of the program, mentor and mentee pairs should meet weekly at any time that works for you two. Accommodate the mentee on the topics and questions that they have, and suggest your own topics that you think would be helpful for them.'
+          }
+        </Text>
+        <p />
+        <Text inherit>
+          {
+            'In addition, we are looking to hold a monthly in-person gathering where all of the mentors and mentees can meet, to allow everyone to get to know each other and build a sense of community. We aim to have a smaller, more intimate cohort for this program, so we can plan this programming around everyone’s availability. We expect everyone to do their best to attend these sessions to get the most out of the program.'
+          }
+        </Text>
+        <p />
+        <Text inherit fw={800} c={theme.other.patinaBlueLight}>
+          {
+            'The overall commitment for mentors is expected to be around 5 hrs/month.'
+          }
+        </Text>
+      </div>
+    </>
+  )
+}

--- a/js/src/patina/pages/mentorship/Mentorship.page.tsx
+++ b/js/src/patina/pages/mentorship/Mentorship.page.tsx
@@ -17,11 +17,13 @@ export function MentorshipPage() {
   const message = (
     <div>
       <Text className={styles.description}>
-        {'The Patina Network mentorship program is open to students currently ' +
-          'enrolled in any US college program or recently graduated who are ' +
-          'interested in guidance with their workplace readiness.'}
+        {
+          'The Patina Network mentorship program will pair you with an experienced mentor in your field and foster a safe environment to explore how culture, career, and life intersect.'
+        }
         <p />
-        {'Sign up to get notified when applications open!'}
+        {
+          'Sophomores or juniors currently enrolled in a US undergraduate program can apply. Applications are now open for Fall 2024!'
+        }
       </Text>
     </div>
   )

--- a/js/src/patina/pages/mentorship/Mentorship.page.tsx
+++ b/js/src/patina/pages/mentorship/Mentorship.page.tsx
@@ -1,6 +1,6 @@
-import { Text } from '@mantine/core'
+import { Space, Text } from '@mantine/core'
 import { About } from '@/patina/pages/mentorship/about/About.tsx'
-// import { Apply } from '@/patina/pages/mentorship/apply/Apply.tsx'
+// import { Apply } from '@/patina/pages/mentorship/apply/TimelineSection.tsx'
 import { Gain } from '@/patina/pages/mentorship/gain/Gain.tsx'
 import { Hero } from '@/patina/components/Hero'
 // import { Details } from '@/patina/pages/mentorship/details/Details.tsx'
@@ -8,6 +8,7 @@ import { Hero } from '@/patina/components/Hero'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
 import { imageUrls } from '@/patina/assets/images'
 import styles from './Mentorship.module.css'
+import { ProgramDetails } from '@/patina/pages/mentorship/program/ProgramDetails.tsx'
 
 /**
  * MentorshipPage component renders a mentorship page layout with multiple sections.
@@ -22,8 +23,10 @@ export function MentorshipPage() {
         }
         <p />
         {
-          'Sophomores or juniors currently enrolled in a US undergraduate program can apply. Applications are now open for Fall 2024!'
+          'Sophomores or juniors currently enrolled in a US undergraduate program can apply.'
         }
+        <br />
+        {'Applications are now open for Fall 2024!'}
       </Text>
     </div>
   )
@@ -39,6 +42,9 @@ export function MentorshipPage() {
         buttonColor={'var(--mantine-color-patina-blue-light)'}
       />
       <About />
+      <Space h={64} />
+      <ProgramDetails />
+      <Space h={64} />
       <Gain />
       {/*<Details />*/}
       {/*<Apply />*/}

--- a/js/src/patina/pages/mentorship/about/About.module.css
+++ b/js/src/patina/pages/mentorship/about/About.module.css
@@ -1,48 +1,44 @@
 .about {
-  margin-bottom: 112px;
   gap: 24px;
 
   @mixin smaller-than $mantine-breakpoint-md {
     gap: 48px;
     flex-direction: column;
-    margin-bottom: 64px;
   }
 }
 
-.aboutTitle,
-.timeCommitmentTitle {
-  color: white;
-  font-weight: 700;
-  line-height: 35px;
-  font-size: 26px;
-}
-
-.aboutText,
-.timeCommitmentText {
+.aboutText {
   color: white;
   font-weight: 400;
   line-height: 28px;
   font-size: 18px;
 }
 
-.right {
-  width: 538px;
-  height: 309px;
-  justify-content: center;
-  justify-items: center;
-  display: contents;
+.quote {
+  justify-self: center;
+  align-self: center;
+  margin-left: 64px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin: 0;
+  }
 }
 
-.quote {
+.quoteText {
   margin: 64px;
   color: white;
   text-align: center;
   font-weight: 700;
   font-size: 34px;
+  height: auto;
 
   @mixin smaller-than $mantine-breakpoint-xs {
     text-align: left;
     margin: 24px;
     font-size: 28px;
   }
+}
+
+.quoteAuthor {
+  text-align: right;
 }

--- a/js/src/patina/pages/mentorship/about/About.tsx
+++ b/js/src/patina/pages/mentorship/about/About.tsx
@@ -9,7 +9,19 @@ export function About() {
         <h2 className={styles.aboutTitle}>{'About the Program'}</h2>
         <Text className={styles.aboutText}>
           {
-            'If you ever felt that you were alone navigating your educational journey or your career, this is a safe space for you to meet someone who can act as an older sibling, relative, or elder who can mentor and coach you to meet your workplace readiness goals. Our mentors will guide you to be more ready for your desired career track.'
+            'Many young people feel uncertain as they navigate their educational and career paths. Our mentors are here to provide personalized guidance, working closely with you to understand your goals and learning style and helping you find a clear path to your career.'
+          }
+          <p />
+          {
+            'We also offer group activities designed to help you connect with other students and mentors while developing essential career skills, such as networking and interview preparation.'
+          }
+          <p />
+          {
+            "Together, we will also explore topics rarely discussed in the workplace, like what it means to be AANHPI in today’s professional environment. We'll explore various AANHPI cultures and celebrate our diverse backgrounds."
+          }
+          <p />
+          {
+            'We hope all participants in our program leave not only with a stronger foundation for their career but also as a committed ally, ready to contribute to a more inclusive workplace for future generations.\n'
           }
         </Text>
         {/*<h2 className={styles.timeCommitmentTitle}>{'Time Commitment'}</h2>*/}

--- a/js/src/patina/pages/mentorship/about/About.tsx
+++ b/js/src/patina/pages/mentorship/about/About.tsx
@@ -1,13 +1,14 @@
-import { Paper, Flex, Text } from '@mantine/core'
+import { Flex, Paper, Space, Stack, Text, Title } from '@mantine/core'
 import styles from './About.module.css'
 
 // Defining the About component
 export function About() {
   return (
     <Flex className={styles.about}>
-      <div className={styles.left}>
-        <h2 className={styles.aboutTitle}>{'About the Program'}</h2>
-        <Text className={styles.aboutText}>
+      <div>
+        <Title order={2}>{'About the Program'}</Title>
+        <Space h={'sm'} />
+        <Text size={'lg'}>
           {
             'Many young people feel uncertain as they navigate their educational and career paths. Our mentors are here to provide personalized guidance, working closely with you to understand your goals and learning style and helping you find a clear path to your career.'
           }
@@ -21,25 +22,22 @@ export function About() {
           }
           <p />
           {
-            'We hope all participants in our program leave not only with a stronger foundation for their career but also as a committed ally, ready to contribute to a more inclusive workplace for future generations.\n'
+            'We hope all participants in our program leave not only with a stronger foundation for their career but also as a committed ally, ready to contribute to a more inclusive workplace for future generations.'
           }
         </Text>
-        {/*<h2 className={styles.timeCommitmentTitle}>{'Time Commitment'}</h2>*/}
-        {/*<Text className={styles.timeCommitmentText}>*/}
-        {/*  {*/}
-        {/*    'Students are expected to commit to a 12 week program where they meet their Mentor for one hour on a weekly basis.'*/}
-        {/*  }*/}
-        {/*</Text>*/}
       </div>
-      <div className={styles.right}>
-        <Paper withBorder>
-          <Text className={styles.quote}>
+      <Stack className={styles.quote}>
+        <Paper withBorder h={'fit-content'}>
+          <Text className={styles.quoteText}>
             {
-              '“I feel more motivated and confident not only in what I want for my future but in reaching out to other professionals and building my network” - Jasmine'
+              '“I feel more motivated and confident not only in what I want for my future but in reaching out to other professionals and building my network”'
             }
+            <Text inherit className={styles.quoteAuthor}>
+              {' - Jasmine'}
+            </Text>
           </Text>
         </Paper>
-      </div>
+      </Stack>
     </Flex>
   )
 }

--- a/js/src/patina/pages/mentorship/gain/Gain.tsx
+++ b/js/src/patina/pages/mentorship/gain/Gain.tsx
@@ -7,21 +7,21 @@ const cardMap = [
   {
     title: 'Field-Specific Mentorship',
     details:
-      'Connect with our Track Mentor who has been in the same shoes as you through education and your future career path. Ask questions specific to your field of interest and how you can better prepare yourself for this specialization.',
+      'Connect with a mentor who has been in the same shoes as you through education and your future career path. Ask questions specific to your field of interest and how you can better prepare yourself for this specialization.',
     img: imageUrls.mentorshipField.src,
     alt: imageUrls.mentorshipField.alt,
   },
   {
     title: 'Networking Skills',
     details:
-      'First networking email, coffee chat, conference, or any type of reach out can be intimidating. Group Mentor will coach a group of Mentees to set a goal for networking readiness, walk you through best examples, and provide feedback to your strategy and drafts before you practice for real.',
+      'The first reach out of any type can be intimidating, whether that be by email, coffee chat or at an event. A mentor from Patina will ease you into it by helping you set a goal for networking readiness, walk you through best examples, and provide feedback for your strategy and drafts before you practice for real. ',
     img: imageUrls.mentorshipNetworking.src,
     alt: imageUrls.mentorshipNetworking.alt,
   },
   {
-    title: 'Interview Prep',
+    title: 'Cultural Awareness and Exploration',
     details:
-      'Practice makes perfect. If you want a non-judgmental coach, Group Mentor, to hold you accountable, practice with us where we will push you to get used to the anxiety of interviews.',
+      'Discover the unique challenges and opportunities that come with being AANHPI in the professional world. Our program goes beyond traditional career guidance by fostering cultural awareness and understanding, enabling us to celebrate and explore the rich diversity of AANHPI cultures.',
     img: imageUrls.mentorshipInterview.src,
     alt: imageUrls.mentorshipInterview.alt,
   },

--- a/js/src/patina/pages/mentorship/program/ProgramDetails.module.css
+++ b/js/src/patina/pages/mentorship/program/ProgramDetails.module.css
@@ -1,0 +1,24 @@
+.programDetails {
+  margin-inline: 64px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin-inline: 0;
+  }
+}
+
+.timelineSection {
+  margin-bottom: 24px;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.programDescription {
+  flex: 1;
+  margin-inline: 64px;
+  min-width: 300px;
+  font-size: 20px;
+
+  @mixin smaller-than $mantine-breakpoint-md {
+    margin-inline: 0;
+  }
+}

--- a/js/src/patina/pages/mentorship/program/ProgramDetails.tsx
+++ b/js/src/patina/pages/mentorship/program/ProgramDetails.tsx
@@ -1,0 +1,193 @@
+import {
+  Flex,
+  Group,
+  List,
+  Space,
+  Stack,
+  Text,
+  ThemeIcon,
+  Timeline,
+  Title,
+  useMantineTheme,
+} from '@mantine/core'
+import { FaDiscord, FaPeopleArrows, FaUsers } from 'react-icons/fa'
+import styles from './ProgramDetails.module.css'
+
+/** Displays details for the mentorship program for mentees */
+export function ProgramDetails() {
+  return (
+    <Stack className={styles.programDetails}>
+      <Flex justify={'center'}>
+        <Title order={2}>{'Program Details'}</Title>
+      </Flex>
+      <Space h={22} />
+      <Group className={styles.timelineSection}>
+        <Stack align={'center'}>
+          <ProgrammingSummary />
+          <Space h={8} />
+          <ProgramTimeline />
+        </Stack>
+        <ProgramText />
+      </Group>
+    </Stack>
+  )
+}
+
+function ProgramTimeline() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <Title order={3}>{'Timeline'}</Title>
+      <Timeline
+        ml={8}
+        mb={16}
+        color={theme.other.patinaBlueLight}
+        bulletSize={24}
+        lineWidth={2}
+      >
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'September 14'}
+            </Text>
+          }
+          fw={700}
+        >
+          <Text mt={4}>{'Introduction to your mentor'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'September 22'}
+            </Text>
+          }
+        >
+          <Text mt={4}>{'Virtual onboarding meeting'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'Week of September 23'}
+            </Text>
+          }
+          lineVariant="dashed"
+        >
+          <Text mt={4}>{'Beginning of the program'}</Text>
+        </Timeline.Item>
+
+        <Timeline.Item
+          title={
+            <Text fw={700} c={theme.other.patinaBlueLight}>
+              {'Week of December 14'}
+            </Text>
+          }
+          lineVariant="dashed"
+        >
+          <Text mt={4}>{'Last week of the program'}</Text>
+        </Timeline.Item>
+      </Timeline>
+    </>
+  )
+}
+
+function ProgrammingSummary() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <Title order={3}>{'Programming'}</Title>
+      <List spacing="xs" size="sm" center>
+        <List.Item
+          icon={
+            <ThemeIcon color={'dark.4'} size={28} radius="xl">
+              <FaPeopleArrows size={18} />
+            </ThemeIcon>
+          }
+        >
+          <Text c={theme.other.patinaBlueLight}>
+            {'Weekly: '}
+            <Text span c={'dark.0'}>
+              {'1:1 with Mentor'}
+            </Text>
+          </Text>
+        </List.Item>
+        <List.Item
+          icon={
+            <ThemeIcon color={'dark.4'} size={28} radius="xl">
+              <FaDiscord size={18} />
+            </ThemeIcon>
+          }
+        >
+          <Text c={theme.other.patinaBlueLight}>
+            {'Monthly (Virtual): '}
+            <Text span c={'dark.0'}>
+              {'Group Mentoring'}
+            </Text>
+          </Text>
+        </List.Item>
+        <List.Item
+          icon={
+            <ThemeIcon color={'dark.4'} size={28} radius="xl">
+              <FaUsers size={18} />
+            </ThemeIcon>
+          }
+        >
+          <Text c={theme.other.patinaBlueLight}>
+            {'Monthly (In-Person): '}
+            <Text span c={'dark.0'}>
+              {'Group Event'}
+            </Text>
+          </Text>
+        </List.Item>
+      </List>
+    </>
+  )
+}
+
+function ProgramText() {
+  const theme = useMantineTheme()
+
+  return (
+    <>
+      <div className={styles.programDescription}>
+        <Text inherit>
+          {
+            'For the fall semester, we are looking to pair mentees one-on-one with a mentor, so that each mentee can have an experience tailored to their individual situation, needs and direction.'
+          }
+        </Text>
+        <p />
+        <Text inherit>
+          {
+            "For the duration of the program, mentor and mentee pairs should meet weekly at any time that works for you two. Come with topics and questions that you'd like to get your mentor's perspective on!"
+          }
+        </Text>
+        <p />
+        <Text inherit>
+          {'In addition, we will hold two monthly events with all the mentees.'}
+        </Text>
+        <p />
+        <Text inherit>
+          {
+            'The first will be virtual sessions to address common topics that would be beneficial regardless of what field or industry you join in the future, such as networking, resume writing, and championing diversity. These sessions will be led by volunteers from Patina, and not your individual mentor.'
+          }
+        </Text>
+        <p />
+        <Text inherit>
+          {
+            'The other will be an in-person gathering where all of the mentors and mentees can meet, to allow everyone to get to know each other and build a sense of community. We aim to have a smaller, more intimate cohort for this program, so we can plan this programming around everyone’s availability. We expect everyone to do their best to attend these sessions to get the most out of the program.'
+          }
+        </Text>
+        <p />
+
+        <Text inherit fw={800} c={theme.other.patinaBlueLight}>
+          {
+            'The overall commitment for mentees is expected to be around 6 hrs/month.'
+          }
+        </Text>
+      </div>
+    </>
+  )
+}

--- a/js/src/patina/theme.ts
+++ b/js/src/patina/theme.ts
@@ -37,7 +37,7 @@ export const themeOverride = createTheme({
       '#009b59',
     ],
     dark: [
-      '#F3F3F3', // dark-0
+      '#FFFFFF', // dark-0
       // '#C1C2C5', // dark-0
       '#A6A7AB', // dark-1
       '#909296', // dark-2


### PR DESCRIPTION
Letting a user pass in Gap to the content page, so that we can
progressively transition the pages to have a consistent gap, and move
all of the layout stuff outside of the individual components.

Reducing the Hero module gap here, but we should do a pass on all of the
pages and remove it.

Having the gap be set inside ContentPage will allow us to handle mobile
more consistently, without having to add it everywhere ourselves.

TEST=manual

Change-Id: Iaee898f401dc610be7a2c942576eea1cc2cca139