### PR TITLE
Blogs: Hide blogs until we have consistent content

### DIFF
--- a/js/src/patina/navbar/NavBar.tsx
+++ b/js/src/patina/navbar/NavBar.tsx
@@ -45,7 +45,7 @@ const links = [
     ],
   },
   { link: '/community', label: 'Events' },
-  { link: '/blog', label: 'Blog' },
+  // { link: '/blog', label: 'Blog' },
   // { label: 'Donate' },
 ]
 

--- a/js/src/patina/pages/home/initiatives/Initiatives.tsx
+++ b/js/src/patina/pages/home/initiatives/Initiatives.tsx
@@ -31,7 +31,7 @@ const detailsMap: CardsProps[] = [
       'Join us for events, where you can form new connections and maybe learn something new!',
     img: imageUrls.scholarshipHome.src,
     alt: imageUrls.scholarshipHome.alt,
-    link: '/events',
+    link: '/community',
   },
 ]
 


### PR DESCRIPTION
Currently, we're looking to onboard people to handle the social media
and marketing. Once we get that up and running, we can turn this back
on.

TEST=manual

Change-Id: Id0ac0d72cc5e02877b1a64afeecedd8005c15f63