### PR TITLE
Java: Bump Java version from 22 to 23

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 22
+          java-version: 23
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 22
+          java-version: 23
       - uses: gradle/actions/setup-gradle@v4
       - working-directory: ./js
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:22-jdk
+FROM openjdk:23-jdk
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(23)
     }
 }
 


### PR DESCRIPTION
The backend broke, since the docker build step in Spring Boot's
:buildBootImage task uses the latest Paketo buildpack version, and
Paketo removed the Java 22 JDK and added the Java 23 JDK, since 22 isn't
a LTS version.

Bumped this to 23 to fix it, but perhaps we should be on 21 so it stays
stable.

TEST=manual

Change-Id: I0897058326017a30e1d94afdb7cd87619c2b3042