### PR TITLE
Patina: Change Community links to Events

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/js/src/patina/Patina.routes.tsx
+++ b/js/src/patina/Patina.routes.tsx
@@ -30,8 +30,8 @@ export const PatinaRoutes = [
     element: <TeamPage />,
   },
   {
-    path: 'community',
-    description: 'Community',
+    path: 'events',
+    description: 'Events',
     element: <CommunityPage />,
   },
   {

--- a/js/src/patina/navbar/NavBar.tsx
+++ b/js/src/patina/navbar/NavBar.tsx
@@ -44,7 +44,7 @@ const links = [
       { link: '/volunteer', label: 'Volunteer' },
     ],
   },
-  { link: '/community', label: 'Events' },
+  { link: '/events', label: 'Events' },
   // { link: '/blog', label: 'Blog' },
   // { label: 'Donate' },
 ]

--- a/js/src/patina/pages/home/initiatives/Initiatives.tsx
+++ b/js/src/patina/pages/home/initiatives/Initiatives.tsx
@@ -31,7 +31,7 @@ const detailsMap: CardsProps[] = [
       'Join us for events, where you can form new connections and maybe learn something new!',
     img: imageUrls.scholarshipHome.src,
     alt: imageUrls.scholarshipHome.alt,
-    link: '/community',
+    link: '/events',
   },
 ]
 

--- a/js/src/patina/pages/home/involved/GetInvolved.tsx
+++ b/js/src/patina/pages/home/involved/GetInvolved.tsx
@@ -34,7 +34,7 @@ export function GetInvolved() {
           description={
             'Join us for events, where you can form new connections and maybe learn something new!'
           }
-          href={'/community'}
+          href={'/events'}
         />
       </div>
     </div>


### PR DESCRIPTION
Change the name of the URL endpoint that is matching and easier to
understand.

Change-Id: I4cf613cb5f1c1a96d935612c7c6a4da9c3b0539b