### PR TITLE
Admin Events: Prepare table for data

### DIFF
--- a/js/src/patina/admin/event/EditEvent.tsx
+++ b/js/src/patina/admin/event/EditEvent.tsx
@@ -1,12 +1,42 @@
 import { Loader, Stack, Title } from '@mantine/core'
-//import { useQuery } from '@tanstack/react-query'
-//import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { EventDataTable } from './EventDataTable.tsx'
 
 export function EditEvent() {
+  const [activePage, setActivePage] = useState(1)
+  const [limit, setLimit] = useState(10)
+
+  const eventsResp = useQuery({
+    queryKey: ['events', limit, activePage],
+    queryFn: async () => {
+      const response = await fetch('/api/events', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`)
+      }
+      return response.json()
+    },
+  })
+
   return (
     <Stack>
-      <Title>{'Edit Event'}</Title>
-      <Loader />
+      <Title order={3}>{'Edit Blog'}</Title>
+      {eventsResp.status === 'success' ?
+        <EventDataTable
+          records={eventsResp.data?.events}
+          total={eventsResp.data?.total}
+          page={activePage}
+          setPage={setActivePage}
+          limit={limit}
+          setLimit={setLimit}
+        />
+      : <Loader />}
     </Stack>
   )
 }

--- a/js/src/patina/admin/event/EventDataTable.tsx
+++ b/js/src/patina/admin/event/EventDataTable.tsx
@@ -1,0 +1,55 @@
+import { DataTable } from 'mantine-datatable'
+
+const PAGE_SIZES = [10, 20, 50]
+
+type EventRowType = {
+  id: number
+  name: string
+  message: string
+  location: string
+  date: string
+}
+type EventDataTableProps = {
+  records: EventRowType[]
+  total: number
+  page: number
+  setPage: any
+  limit: number
+  setLimit: any
+}
+export function EventDataTable({
+  records,
+  total,
+  page,
+  setPage,
+  limit,
+  setLimit,
+}: EventDataTableProps) {
+  return (
+    <DataTable
+      withTableBorder
+      withColumnBorders
+      columns={[
+        { accessor: 'id' },
+        { accessor: 'name' },
+        { accessor: 'message' },
+        { accessor: 'location' },
+        { accessor: 'date' },
+        {
+          accessor: 'actions',
+          title: 'Actions',
+          width: '0%',
+          // TODO: [Martin] Enable edit/delete actions
+          // render: (row) => <EditActions blogID={row.id} />,
+        },
+      ]}
+      records={records}
+      totalRecords={total}
+      recordsPerPage={limit}
+      page={page}
+      onPageChange={(p) => setPage(p)}
+      recordsPerPageOptions={PAGE_SIZES}
+      onRecordsPerPageChange={setLimit}
+    />
+  )
+}


### PR DESCRIPTION
Populate data table with events data. Pagination displayed but not set
up.

https://patina-dev.nyc3.digitaloceanspaces.com/screenshot/Screenshot-2024-11-11T19:15:13-MartinM-EditEventsTable.png

TEST=manual
Ran page locally to verify feature works.

Change-Id: I355044bc56a07ec857075e41bcb3a2be863e6df5