### PR TITLE
AdminEvent: Enable Delete Event

### DIFF
--- a/js/src/patina/admin/event/AdminEvent.page.tsx
+++ b/js/src/patina/admin/event/AdminEvent.page.tsx
@@ -19,7 +19,6 @@ export function AdminEventPage() {
   const [message, setMessage] = useState('')
   const [location, setLocation] = useState('')
   const [date, setDate] = useState<Date | null>()
-  const [eventId, setEventId] = useState('')
 
   const handleAdd = async (event: { preventDefault: () => void }) => {
     event.preventDefault()
@@ -37,29 +36,6 @@ export function AdminEventPage() {
         notifications.show({
           title: 'Event Submitted',
           message: 'Your Event titled: was successfully submitted!',
-          color: 'green',
-          position: 'top-right',
-        })
-      } else {
-        console.error('HTTP error:', response.statusText)
-        // Handle the HTTP error response here
-      }
-    } catch (error) {
-      console.error('Fetch error:', error)
-    }
-  }
-
-  const handleDelete = async (event: { preventDefault: () => void }) => {
-    event.preventDefault()
-
-    try {
-      const response = await fetch(`/api/admin/event/delete/${eventId}`, {
-        method: 'DELETE',
-      })
-      if (response.ok) {
-        notifications.show({
-          title: 'Event Deleted',
-          message: 'Your Event titled: was successfully Deleted!',
           color: 'green',
           position: 'top-right',
         })
@@ -121,18 +97,6 @@ export function AdminEventPage() {
         </Stack>
       </form>
       <Space h="xl" />
-      <form onSubmit={handleDelete}>
-        <Stack>
-          <Title order={3}>{'Delete Event'}</Title>
-          <TextInput
-            label="Event ID"
-            value={eventId}
-            onChange={(event) => setEventId(event.currentTarget.value)}
-            required
-          />
-          <Button type="submit">{'Delete'}</Button>
-        </Stack>
-      </form>
       <EditEvent />
     </Container>
   )

--- a/js/src/patina/admin/event/EditEvent.tsx
+++ b/js/src/patina/admin/event/EditEvent.tsx
@@ -26,7 +26,7 @@ export function EditEvent() {
 
   return (
     <Stack>
-      <Title order={3}>{'Edit Blog'}</Title>
+      <Title order={3}>{'Edit Event'}</Title>
       {eventsResp.status === 'success' ?
         <EventDataTable
           records={eventsResp.data?.events}

--- a/js/src/patina/admin/event/EventDataTable.tsx
+++ b/js/src/patina/admin/event/EventDataTable.tsx
@@ -41,7 +41,9 @@ export function EventDataTable({
           accessor: 'actions',
           title: 'Actions',
           width: '0%',
-          render: (row) => <EventEditActions eventID={row.id} />,
+          render: (row) => (
+            <EventEditActions eventID={row.id} eventName={row.name} />
+          ),
         },
       ]}
       records={records}

--- a/js/src/patina/admin/event/EventDataTable.tsx
+++ b/js/src/patina/admin/event/EventDataTable.tsx
@@ -1,4 +1,5 @@
 import { DataTable } from 'mantine-datatable'
+import { EventEditActions } from './EventEditActions.tsx'
 
 const PAGE_SIZES = [10, 20, 50]
 
@@ -17,6 +18,7 @@ type EventDataTableProps = {
   limit: number
   setLimit: any
 }
+
 export function EventDataTable({
   records,
   total,
@@ -39,8 +41,7 @@ export function EventDataTable({
           accessor: 'actions',
           title: 'Actions',
           width: '0%',
-          // TODO: [Martin] Enable edit/delete actions
-          // render: (row) => <EditActions blogID={row.id} />,
+          render: (row) => <EventEditActions eventID={row.id} />,
         },
       ]}
       records={records}

--- a/js/src/patina/admin/event/EventEditActions.tsx
+++ b/js/src/patina/admin/event/EventEditActions.tsx
@@ -1,19 +1,49 @@
 import { ActionIcon, Button, Center, Group, Modal, Text } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { IconEdit, IconTrash } from '@tabler/icons-react'
+import { notifications } from '@mantine/notifications'
 
-export function EventEditActions({ eventID }: { eventID: number }) {
+export function EventEditActions({
+  eventID,
+  eventName,
+}: {
+  eventID: number
+  eventName: string
+}) {
   const [opened, { open, close }] = useDisclosure(false)
 
+  const handleDelete = async (event: { preventDefault: () => void }) => {
+    event.preventDefault()
+
+    try {
+      const response = await fetch(`/api/admin/event/delete/${eventID}`, {
+        method: 'DELETE',
+      })
+      if (response.ok) {
+        notifications.show({
+          title: 'Event Deleted',
+          message: `Your Event titled: ${eventName} was successfully Deleted!`,
+          color: 'green',
+          position: 'top-right',
+        })
+      } else {
+        console.error('HTTP error:', response.statusText)
+        // Handle the HTTP error response here
+      }
+    } catch (error) {
+      console.error('Fetch error:', error)
+    }
+    close()
+  }
   return (
     <Group gap={4} justify="left" wrap="nowrap">
       <Modal opened={opened} onClose={close} title={'Confirm Delete'}>
-        <Text>{`Are you sure you want to delete event ID ${eventID}?`}</Text>
+        <Text>{`Are you sure you want to delete event: ${eventName}?`}</Text>
         <Center>
           <Button mx="sm" my="sm" onClick={close}>
             {'Cancel'}
           </Button>
-          <Button color="red" mx="sm" my="sm">
+          <Button color="red" mx="sm" my="sm" onClick={handleDelete}>
             {'Delete'}
           </Button>
         </Center>

--- a/js/src/patina/admin/event/EventEditActions.tsx
+++ b/js/src/patina/admin/event/EventEditActions.tsx
@@ -1,0 +1,34 @@
+import { ActionIcon, Button, Center, Group, Modal, Text } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { IconEdit, IconTrash } from '@tabler/icons-react'
+
+export function EventEditActions({ eventID }: { eventID: number }) {
+  const [opened, { open, close }] = useDisclosure(false)
+
+  return (
+    <Group gap={4} justify="left" wrap="nowrap">
+      <Modal opened={opened} onClose={close} title={'Confirm Delete'}>
+        <Text>{`Are you sure you want to delete event ID ${eventID}?`}</Text>
+        <Center>
+          <Button mx="sm" my="sm" onClick={close}>
+            {'Cancel'}
+          </Button>
+          <Button color="red" mx="sm" my="sm">
+            {'Delete'}
+          </Button>
+        </Center>
+      </Modal>
+      <ActionIcon
+        size="sm"
+        variant="subtle"
+        color="blue"
+        onClick={() => console.log('Edit')}
+      >
+        <IconEdit size={16} />
+      </ActionIcon>
+      <ActionIcon size="sm" variant="subtle" color="red" onClick={open}>
+        <IconTrash size={16} />
+      </ActionIcon>
+    </Group>
+  )
+}


### PR DESCRIPTION
Removed the old method of deleting an event by manually inserting an
event ID and enabled it through actions in the events table. Also added
a small delete check to make sure the user wants to delete the event. I
also moved and edited the code for the delete notification to display
the name of the event that was deleted.

DeleteEventModal.png
https://patina-dev.nyc3.digitaloceanspaces.com/screenshot/Screenshot-2024-11-13T21:13:27-MartinM-DeleteEventModal.png

DeleteEventNotif.png
 https://patina-dev.nyc3.digitaloceanspaces.com/screenshot/Screenshot-2024-11-13T21:15:09-MartinM-DeleteEventNotif.png

TEST=manual
Ran page locally to verify feature works.

Change-Id: I4b666e07554fe5afabbc157bfbd1309a65bcb46f