### PR TITLE
Team: Update CSS

### DIFF
--- a/js/src/patina/assets/images.ts
+++ b/js/src/patina/assets/images.ts
@@ -165,31 +165,39 @@ export const imageUrls = {
   },
   cinthia: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/cinthia.png',
-    alt: 'Cinthia smiling at the camera.',
+    alt: 'Headshot of Cinthia.',
   },
   andrea: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/andrea.png',
-    alt: 'Andrea smiling at the camera.',
+    alt: 'Headshot of Andrea.',
   },
   celina: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/celina.png',
-    alt: 'Celina smiling at the camera.',
+    alt: 'Headshot of Celina.',
   },
   joan: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/joan.png',
-    alt: 'Joan smiling at the camera.',
+    alt: 'Headshot of Joan.',
   },
   kevin: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/kevin.png',
-    alt: 'Kevin smiling at the camera.',
+    alt: 'Headshot of Kevin Oh.',
   },
   sara: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/sara.jpg',
-    alt: 'Sara smiling at the camera.',
+    alt: 'Headshot of Sara.',
   },
   henry: {
     src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/henry.png',
-    alt: 'Henry smiling at the camera.',
+    alt: 'Headshot of Henry.',
+  },
+  valerie: {
+    src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/valerie.png',
+    alt: 'Headshot of Valerie.',
+  },
+  kevinma: {
+    src: 'https://patina-prod.nyc3.cdn.digitaloceanspaces.com/webimg/kevinma.png',
+    alt: 'Headshot of Kevin Ma.',
   },
   missionKnife: {
     src: 'https://patina-prod.nyc3.digitaloceanspaces.com/webimg/missionKnife.png',

--- a/js/src/patina/pages/about/team/PersonCard.module.css
+++ b/js/src/patina/pages/about/team/PersonCard.module.css
@@ -1,24 +1,22 @@
 .card {
   padding: 32px;
   border-radius: 12px;
-  width: 180px;
+  min-width: 240px;
+  flex: 1;
+  width: auto;
+  max-width: 300px;
   height: 320px;
 
   @mixin smaller-than $mantine-breakpoint-md {
     padding: 24px;
-    width: 164px;
-    height: 288px;
+    margin: auto;
+    max-width: 300px;
   }
 }
 
 .image {
   height: 148px;
   width: 148px;
-
-  @mixin smaller-than $mantine-breakpoint-md {
-    height: 120px;
-    width: 120px;
-  }
 }
 
 .email {

--- a/js/src/patina/pages/about/team/Team.module.css
+++ b/js/src/patina/pages/about/team/Team.module.css
@@ -1,0 +1,6 @@
+.title {
+  @mixin smaller-than $mantine-breakpoint-xs {
+    text-align: center;
+    width: 100%;
+  }
+}

--- a/js/src/patina/pages/about/team/Team.page.tsx
+++ b/js/src/patina/pages/about/team/Team.page.tsx
@@ -1,36 +1,45 @@
-import { Title, Space, Group, Stack } from '@mantine/core'
+import { Group, Space, Stack, Title } from '@mantine/core'
 import { ContentPage } from '@/patina/components/ContentPage.tsx'
 import {
-  boardMembers,
   advisors,
+  boardMembers,
   interns,
 } from '@/patina/pages/about/team/teamData.ts'
 import { PersonCard } from '@/patina/pages/about/team/PersonCard.tsx'
+import styles from './Team.module.css'
 
 export function TeamPage() {
   return (
     <ContentPage>
       <Stack w={'100%'} align={'flex-start'}>
-        <Title order={1}>{'Our Team'}</Title>
+        <Title order={1} className={styles.title}>
+          {'Our Team'}
+        </Title>
         <Space h="md" />
-        <Title order={2}>{'Board of Directors'}</Title>
-        <Group component={'ul'} p={0}>
+        <Title order={2} className={styles.title}>
+          {'Board of Directors'}
+        </Title>
+        <Group component={'ul'} p={0} w={'100%'}>
           {boardMembers.map((boardMember) => (
             <PersonCard {...boardMember} />
           ))}
         </Group>
         <Space h="md" />
 
-        <Title order={2}>{'Advisors'}</Title>
-        <Group component={'ul'} p={0}>
+        <Title order={2} className={styles.title}>
+          {'Advisors'}
+        </Title>
+        <Group component={'ul'} p={0} w={'100%'}>
           {advisors.map((boardMember) => (
             <PersonCard {...boardMember} />
           ))}
         </Group>
         <Space h="md" />
 
-        <Title order={2}>{'Interns'}</Title>
-        <Group component={'ul'} p={0}>
+        <Title order={2} className={styles.title}>
+          {'Interns'}
+        </Title>
+        <Group component={'ul'} p={0} w={'100%'}>
           {interns.map((boardMember) => (
             <PersonCard {...boardMember} />
           ))}

--- a/js/src/patina/pages/about/team/teamData.ts
+++ b/js/src/patina/pages/about/team/teamData.ts
@@ -31,8 +31,8 @@ export const boardMembers = [
   {
     name: 'Joan Lee',
     role: 'Board Member',
-    email: '',
-    linkedInUrl: '',
+    email: 'joan@patinanetwork.org',
+    linkedInUrl: 'https://www.linkedin.com/in/joxnlee/',
     webUrl: '',
     githubUrl: '',
     imageSrc: imageUrls.joan.src,
@@ -46,6 +46,33 @@ export const boardMembers = [
     githubUrl: '',
     imageSrc: imageUrls.kevin.src,
   },
+  {
+    name: 'Kevin Ma',
+    role: 'Board Member',
+    email: 'kevinma@patinanetwork.org',
+    linkedInUrl: 'https://www.linkedin.com/in/kevin-ma-cpa-811892119/',
+    webUrl: '',
+    githubUrl: '',
+    imageSrc: imageUrls.kevinma.src,
+  },
+  {
+    name: 'Henry Chen',
+    role: 'Board Member',
+    email: 'henry@patinanetwork.org',
+    linkedInUrl: 'https://www.linkedin.com/in/arklian/',
+    webUrl: '',
+    githubUrl: 'https://github.com/arklian',
+    imageSrc: imageUrls.henry.src,
+  },
+  {
+    name: 'Valerie Lin',
+    role: 'Board Member',
+    email: 'valerie@patinanetwork.org',
+    linkedInUrl: 'https://linkedin.com/in/xvalerielin',
+    webUrl: '',
+    githubUrl: '',
+    imageSrc: imageUrls.valerie.src,
+  },
 ]
 
 export const advisors = [
@@ -57,15 +84,6 @@ export const advisors = [
     webUrl: '',
     githubUrl: '',
     imageSrc: imageUrls.sara.src,
-  },
-  {
-    name: 'Henry Chen',
-    role: 'SWE Manager',
-    email: 'hjc77@cornell.edu',
-    linkedInUrl: 'https://www.linkedin.com/in/arklian/',
-    webUrl: '',
-    githubUrl: 'https://github.com/arklian',
-    imageSrc: imageUrls.henry.src,
   },
 ]
 


### PR DESCRIPTION
Made cards wider so that names and emails no longer cut out.
Four cards per row now instead of six.
Centered text and cards on mobile

TEST=manual

Change-Id: I0f4b40158b85c92bbe0f9e6e280de0cf981cf527