### PR TITLE
PatChats: Fixed Matching

### DIFF
--- a/src/main/java/org/patinanetwork/patchats/ops/MatchPatChatMemberOp.java
+++ b/src/main/java/org/patinanetwork/patchats/ops/MatchPatChatMemberOp.java
@@ -21,7 +21,8 @@ public class MatchPatChatMemberOp {
     public List<List<PatChatMember>> matchPatChatMember() {
         List<PatChatMember> allMembers = patChatRepo.listPatChatMembers();
 
-        if (allMembers == null || allMembers.isEmpty()) {
+        // Can't match if there are less than two people in the database
+        if (allMembers == null || allMembers.size() < 2) {
             throw new RuntimeException("No members found in the database");
         }
 


### PR DESCRIPTION
Changed the throw condition to when total member list is less than 2
 since index 1 should always be filtered out

Change-Id: I1f79fd75f86bc6c208b63be452bf83baa75513c2