### PR TITLE
Vite: Fix tabler/react-icon loading all icons

### DIFF
--- a/js/vite.config.ts
+++ b/js/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@test-utils': path.resolve(__dirname, './test-utils'),
+      // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
+      '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs',
     },
   },
 })


### PR DESCRIPTION
Vite was being slow since it was loading all of the icons in
tabler/react-icons. Not sure what changed to cause this issue, but
adding the solution from the following reddit thread fixes the issue.

https://old.reddit.com/r/reactjs/comments/1g3tsiy/trouble_with_vite_tablericons_5600_requests/

TEST=manual
Loading vite locally no longer makes 5k icon load requests.

Change-Id: Ibf87be065926ef68588917db819223abaadb27d2