### PR TITLE
Revert "Patchats: create a client side op for broadcast"

### DIFF
--- a/src/main/java/org/patinanetwork/discordbot/DiscordUserClient.java
+++ b/src/main/java/org/patinanetwork/discordbot/DiscordUserClient.java
@@ -1,8 +1,6 @@
 package org.patinanetwork.discordbot;
 
-import net.dv8tion.jda.api.JDA;
 import org.patinanetwork.discordbot.ops.AddDiscordUserOp;
-import org.patinanetwork.discordbot.ops.BroadcastPatChatMatchingOp;
 import org.patinanetwork.discordbot.ops.GetDiscordUserOp;
 import org.patinanetwork.discordbot.ops.ListDiscordUserOp;
 import org.patinanetwork.discordbot.protos.AddDiscordUserReq;
@@ -11,7 +9,6 @@ import org.patinanetwork.discordbot.protos.GetDiscordUserReq;
 import org.patinanetwork.discordbot.protos.GetDiscordUserResp;
 import org.patinanetwork.discordbot.protos.ListDiscordUsersResp;
 import org.patinanetwork.discordbot.repo.DiscordUserRepo;
-import org.patinanetwork.patchats.PatChatClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,14 +18,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class DiscordUserClient {
     DiscordUserRepo discordUserRepo;
-    PatChatClient patChatClient;
-    JDA jda;
 
-    public DiscordUserClient(
-            @Qualifier("PsqlDiscordUserRepo") DiscordUserRepo discordUserRepo, PatChatClient patChatClient, JDA jda) {
+    public DiscordUserClient(@Qualifier("PsqlDiscordUserRepo") DiscordUserRepo discordUserRepo) {
         this.discordUserRepo = discordUserRepo;
-        this.patChatClient = patChatClient;
-        this.jda = jda;
     }
 
     public GetDiscordUserResp getDiscordUser(GetDiscordUserReq req) {
@@ -41,9 +33,5 @@ public class DiscordUserClient {
 
     public AddDiscordUserResp addDiscordUser(AddDiscordUserReq req) {
         return new AddDiscordUserOp(discordUserRepo).run(req);
-    }
-
-    public void broadcastPatChatMatching() {
-        new BroadcastPatChatMatchingOp(discordUserRepo, patChatClient, jda).run();
     }
 }


### PR DESCRIPTION
This reverts commit 5a7b399444d3e7b6eff69bd5c56e64cb8f412387.

This commit breaks the build with a circular dependency.

Details
-------------------------------------------------------------

Description:

The dependencies of some of the beans in the application context form a cycle:

┌─────┐
|  discordUserClient defined in file [/Users/arklian/patina/build/classes/java/main/org/patinanetwork/discordbot/DiscordUserClient.class]
↑     ↓
|  JDAInitializer defined in file [/Users/arklian/patina/build/classes/java/main/org/patinanetwork/discordbot/JDAInitializer.class]
↑     ↓
|  JDAEventListener defined in file [/Users/arklian/patina/build/classes/java/main/org/patinanetwork/discordbot/JDAEventListener.class]
└─────┘

Action:

Relying upon circular references is discouraged and they are prohibited by default. Update your application to remove the dependency cycle between beans. As a last resort, it may be possible to break the cycle automatically by setting spring.main.allow-circular-references to true.

Change-Id: I18f6d8c7a695b9c28731b234bc4a4133eddc91c7