### PR TITLE
Footer: Fix horizontal scrolling in mobile

### DIFF
--- a/js/src/patina/components/Footer.module.css
+++ b/js/src/patina/components/Footer.module.css
@@ -1,8 +1,10 @@
 .footer {
   display: flex;
+  flex-direction: column;
   min-height: 56px;
   height: auto;
   width: 100%;
+  align-items: center;
   justify-content: center;
   background-color: var(--mantine-color-dark-6);
 }
@@ -43,4 +45,9 @@
   flex-direction: row;
   justify-content: space-between;
   gap: 16px;
+}
+
+.nonprofitText {
+  padding-inline: 20px;
+  padding-bottom: 12px;
 }

--- a/js/src/patina/components/Footer.tsx
+++ b/js/src/patina/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Text, UnstyledButton } from '@mantine/core'
+import { ActionIcon, Flex, Text, UnstyledButton } from '@mantine/core'
 import { FaEnvelope, FaInstagram, FaLinkedin } from 'react-icons/fa'
 import { ReactNode } from 'react'
 import styles from './Footer.module.css'
@@ -16,7 +16,7 @@ export function Footer() {
             <PatinaBadge />
           </UnstyledButton>
         </div>
-        <Text px={30} fs="italic">
+        <Text visibleFrom="xs" px={30} fs="italic">
           {'Patina Network is a 501(c)(3) non-profit organization.'}
         </Text>
         <div className={styles.footerLinks}>
@@ -33,6 +33,11 @@ export function Footer() {
           </FooterIconLink>
         </div>
       </div>
+      <Flex hiddenFrom="xs">
+        <Text px={30} fs="italic">
+          {'Patina Network is a 501(c)(3) non-profit organization.'}
+        </Text>
+      </Flex>
     </div>
   )
 }


### PR DESCRIPTION
Text was too wide to fix the three sections horizontally without it
scrolling left to right, so moved the non profit text to a row below for
mobile.

TEST=manual

Change-Id: I4a650298590a535f503c096875a5294159acae35