### PR TITLE
Docker: Use Dockerfile instead of Spring task.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Gradle
+.gradle
+build
+
+# Node
+js/node_modules
+js/dist
+
+# IDE
+.idea
+*.iml
+
+# OS-specific
+.DS_Store

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,17 +10,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          path: .
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 23
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
 
       - name: Log in to DigitalOcean Container Registry
         uses: docker/login-action@v3
@@ -32,9 +21,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set Timezone
+        uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "America/New_York"
+
+      - name: Set image tags
+        run: |
+          echo "TIMESTAMP=$(date +%Y.%m.%d-%H.%M.%S)" >> $GITHUB_ENV
+          echo "GIT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
       - name: Build and push Docker image
-        env:
-          DO_DOCKER_IMAGE_UPLOAD_PAT: ${{ secrets.DO_DOCKER_IMAGE_UPLOAD_PAT }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: ./gradlew tagAndPushDockerImage -PimageTags=${{ env.IMAGE_TAG }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            patina-site:latest
+            patina-site:${{ env.TIMESTAMP }}
+            patina-site:${{ env.GIT_SHA }}
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ out/
 
 ### Infisical ###
 .infisical.json
+
+### Secrets ###
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,57 @@
-FROM openjdk:23-jdk
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
-EXPOSE 8080
+# Stage 1: Build the application
+FROM gradle:jdk23 AS builder
+WORKDIR /app
+
+# Copy the entire project
+COPY . .
+
+# Build the Spring Boot executable jar.
+RUN ./gradlew bootJar --no-daemon
+
+# Stage 2: Create the final, runnable image
+FROM eclipse-temurin:23-jre
+WORKDIR /app
+
+# Copy the application jar from the 'builder' stage
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# Install dependencies for Playwright.
+# Hard coding it instead of using npx playwright install-deps since it increases the image size by 700MB.
+# See Firefox + OS version to find the list of deps here:
+# https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/nativeDeps.ts
+RUN apt-get update \
+    && apt-get install -y libasound2t64 \
+      libatk1.0-0t64 \
+      libcairo-gobject2 \
+      libcairo2 \
+      libdbus-1-3 \
+      libfontconfig1 \
+      libfreetype6 \
+      libgdk-pixbuf-2.0-0 \
+      libglib2.0-0t64 \
+      libgtk-3-0t64 \
+      libpango-1.0-0 \
+      libpangocairo-1.0-0 \
+      libx11-6 \
+      libx11-xcb1 \
+      libxcb-shm0 \
+      libxcb1 \
+      libxcomposite1 \
+      libxcursor1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxi6 \
+      libxrandr2 \
+      libxrender1 \
+    && apt-get -y autoclean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Copy browsers from the browser install in gradle.
+COPY --from=builder /app/build/playwright-browsers /app/browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/browsers
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN mkdir -p /app/playwright
+
+# Set the entrypoint to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,67 @@
+# Gemini Code Assistant Context
+
+This document provides context for the Gemini code assistant to understand the Patina project.
+
+## Project Overview
+
+The Patina project is a full-stack web application.
+
+**Backend:**
+
+*   **Language:** Java
+*   **Framework:** Spring Boot
+*   **Build Tool:** Gradle
+*   **Key Dependencies:**
+    *   Spring Web
+    *   Spring Security (with OAuth2)
+    *   PostgreSQL JDBC Driver
+    *   JDA (Java Discord API)
+    *   Protobuf
+
+**Frontend:**
+
+*   **Framework:** React
+*   **Language:** TypeScript
+*   **Build Tool:** Vite
+*   **Package Manager:** pnpm
+*   **UI Library:** Mantine
+*   **Key Dependencies:**
+    *   React Router
+    *   React Query
+    *   Tiptap (rich text editor)
+
+**Architecture:**
+
+The project is a monolith with two main modules:
+
+*   `js`: The React frontend.
+*   `src`: The Spring Boot backend.
+
+The Gradle build is configured to build the frontend first and then package it into the Spring Boot application.
+
+## Building and Running
+
+**Backend:**
+
+*   Run the application: `./gradlew bootRun`
+*   Build the application: `./gradlew build`
+*   Run tests: `./gradlew test`
+
+**Frontend:**
+
+*   Install dependencies: `pnpm install`
+*   Run in development mode: `pnpm dev`
+*   Build for production: `pnpm build`
+*   Run tests: `pnpm test`
+
+## Development Conventions
+
+*   **Code Formatting:**
+    *   Java: `com.palantir.java-format`
+    *   TypeScript/TSX: `prettier`
+*   **Linting:**
+    *   TypeScript/TSX: `eslint`
+    *   CSS: `stylelint`
+*   **Testing:**
+    *   Java: JUnit Platform
+    *   TypeScript/TSX: `vitest` with React Testing Library

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,5 @@
+To build the docker locally, use this command:  
+`docker build -t patina:local .`
+
+To run the local docker container, use:  
+`docker run -p 8080:8080 --env-file ./.env patina:local`

--- a/src/main/java/org/patinanetwork/givebutter/util/GiveButterAuth.java
+++ b/src/main/java/org/patinanetwork/givebutter/util/GiveButterAuth.java
@@ -44,8 +44,8 @@ public class GiveButterAuth {
                     .launch(new BrowserType.LaunchOptions().setHeadless(true).setTimeout(10000));
             BrowserContext context = browser.newContext(new NewContextOptions()
                     .setUserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0")
-                    .setRecordVideoDir(Paths.get("playwright/"))
-                    .setViewportSize(1920, 1080)
+                    //                    .setRecordVideoDir(Paths.get("playwright/"))
+                    //                    .setViewportSize(1920, 1080)
                     .setStorageStatePath(STORAGE_STATE_PATH));
             LOGGER.info("Loaded browser context");
 
@@ -108,7 +108,6 @@ public class GiveButterAuth {
                     .isVisible()) {
                 LOGGER.info("2FA Required");
 
-                //                page.click("button[name=\"Send Code\"]");
                 page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Send Code"))
                         .click();
 


### PR DESCRIPTION
Use a custom Dockerfile since we need to install dependencies for
Playwright to run.

The Docker image build is split up into two stages, build and runnable
in order to reduce image size.

We copy over the browsers and the Spring JAR from the build stage, but
we need to still install the libs onto the runnable image. These are
hard coded, since installing it through npx adds 700MB to the file size
and conflicts with the Java version of Playwright unless we keep the
versions pegged.

Updated the CD pipeline to call docker directly.

TEST=manual
Ran the container in Docker locally, and Playwright was working.
Hopefully the Git Action works, since it's not tested in this yet.

Change-Id: Ia8af272ca32054de67c9f581d3fd27b63b14cd95